### PR TITLE
Fix a typo in the 'totalassets' field name

### DIFF
--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetGroupStatsCollector.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetGroupStatsCollector.java
@@ -242,7 +242,7 @@ public class AssetGroupStatsCollector {
                 doc.put("@id", id);
                 doc.put(AssetDocumentFields.DOC_TYPE, "count_asset");
                 doc.put("typeCount", assetCounts.get("assettype"));
-                doc.put("totalAssets", assetCounts.get("totalassets"));
+                doc.put("totalassets", assetCounts.get("totalassets"));
 
                 batch.add(BatchItem.documentEntry(ASSET_GROUP_STATS_INDEX, id, doc));
             }


### PR DESCRIPTION
Thanks to Arun for finding this

This created a problem in the asset trend graph