### PR TITLE
fix:[NEXT-175] Properly deserialize Asset from Elastic; populate tags in new format

### DIFF
--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -20,10 +20,6 @@ public class AssetDTO {
      */
     private final Map<String, Object> additionalProperties = new HashMap<>();
 
-    public boolean isOwner() {
-        return cloudType != null && cloudType.equalsIgnoreCase(reportingSource);
-    }
-
     /**
      * This is the unique id for the asset, which depends on the source & type as well as the unique
      * id for the instance. This unique id the same for the lifetime of the asset.
@@ -92,6 +88,11 @@ public class AssetDTO {
     @Getter
     @JsonProperty(AssetDocumentFields.RESOURCE_ID)
     private String resourceId;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.TAGS)
+    private Map<String, String> tags;
 
     @Setter
     @Getter

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -19,6 +19,8 @@ import lombok.Getter;
 import lombok.NonNull;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 /**
  * Use the Builder to set properties, and {@link #createFrom(Map)} to convert from a mapped data
@@ -28,6 +30,7 @@ import org.apache.commons.lang3.StringUtils;
 public class AssetDocumentHelper {
 
     static private String MAPPER_RAW_DATA = "rawData";
+    private static final Logger LOGGER = LogManager.getLogger(AssetDocumentHelper.class);
 
     static private Map<String, String> accountIdNameMap = new HashMap<>();
     @NonNull
@@ -57,6 +60,10 @@ public class AssetDocumentHelper {
             if (docIdFields.contains(AssetDocumentFields.ACCOUNT_ID)) {
                 docId = STR."\{StringHelper.indexName(dataSource, type)}_\{docId}";
             }
+        }
+        if (StringUtils.isBlank(docId)) {
+            LOGGER.info(STR."docId is not valid: '\{docId}' docIdFields=\{docIdFields} mapper data=\{MapHelper.toJsonString(data)}");
+            throw new JobException(STR."docId is not valid: '\{docId}', mapper data & config don't match for type=\{type}");
         }
         return docId;
     }

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/search/ElasticQueryAssetResponse.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/search/ElasticQueryAssetResponse.java
@@ -5,20 +5,14 @@ import com.paladincloud.common.assets.AssetDTO;
 import java.util.List;
 
 public class ElasticQueryAssetResponse {
+
     @JsonProperty("_scroll_id")
     public String scrollId;
     public Hits hits;
 
     public static class Hits {
 
-        public HitsTotal total;
         public List<HitsDoc> hits;
-
-        public static class HitsTotal {
-
-            public long value;
-            public String relation;
-        }
 
         public static class HitsDoc {
 
@@ -26,8 +20,6 @@ public class ElasticQueryAssetResponse {
             public String index;
             @JsonProperty("_id")
             public String id;
-            @JsonProperty("_score")
-            public long score;
             @JsonProperty("_source")
             public AssetDTO source;
         }

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/search/ElasticSearchHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/search/ElasticSearchHelper.java
@@ -61,7 +61,8 @@ public class ElasticSearchHelper {
     public <T> T invokeCheckAndConvert(Class<T> clazz, HttpMethod method, String endpoint,
         String payLoad) throws IOException {
         var response = invokeAndCheck(method, endpoint, payLoad);
-        return JsonHelper.fromString(clazz, response.getBody());
+        var body = response.getBody();
+        return JsonHelper.fromString(clazz, body);
     }
 
     /**
@@ -158,11 +159,14 @@ public class ElasticSearchHelper {
         int totalDocumentCount = getDocumentCount(indexName);
         boolean scroll = totalDocumentCount > ElasticSearchHelper.MAX_RETURNED_RESULTS;
 
-        StringBuilder filterPath = new StringBuilder("&filter_path=_scroll_id,");
-        for (String _filter : filters) {
-            filterPath.append("hits.hits._source.").append(_filter).append(",");
+        var filterPath = new StringBuilder();
+        if (filters != null && !filters.isEmpty()) {
+            filterPath = new StringBuilder("&filter_path=_scroll_id,");
+            for (String _filter : filters) {
+                filterPath.append("hits.hits._source.").append(_filter).append(",");
+            }
+            filterPath.deleteCharAt(filterPath.length() - 1);
         }
-        filterPath.deleteCharAt(filterPath.length() - 1);
 
         String endPoint = STR."\{indexName}/_search?scroll=1m\{filterPath}&size=\{Math.min(totalDocumentCount,
             ElasticSearchHelper.MAX_RETURNED_RESULTS)}";

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
@@ -1,12 +1,14 @@
 package com.paladincloud.commons.assets;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.paladincloud.common.AssetDocumentFields;
 import com.paladincloud.common.assets.AssetDTO;
+import com.paladincloud.common.search.ElasticQueryAssetResponse;
 import com.paladincloud.common.util.JsonHelper;
 import com.paladincloud.common.util.TimeHelper;
 import java.time.ZonedDateTime;
@@ -39,6 +41,17 @@ public class AssetDTOTests {
             asMap.get(AssetDocumentFields.FIRST_DISCOVERED));
         assertEquals(TimeHelper.formatZeroSeconds(dateTime),
             asMap.get(AssetDocumentFields.DISCOVERY_DATE));
+    }
+
+    @Test
+    void elasticResponseDeserialized() throws JsonProcessingException {
+        var sampleJson = getElasticResponse();
+//        var deserialized = JsonHelper.objectMapper.readValue(sampleJson, ElasticQueryAssetResponse.class);
+        var deserialized = JsonHelper.fromString(ElasticQueryAssetResponse.class, sampleJson);
+        assertNotNull(deserialized);
+        assertNotNull(deserialized.hits);
+        assertNotNull(deserialized.hits.hits);
+        assertFalse(deserialized.hits.hits.isEmpty());
     }
 
     @Test
@@ -100,8 +113,70 @@ public class AssetDTOTests {
                 "discoverydate": "2024-09-05 14:57:00+0000",
                 "firstdiscoveredon": "2024-09-05 14:57:00+0000",
                 "ec2_relations": "ec2",
-                "tags.foo": "bar"
+                "tags": {"environment": "bar" }
             }
         """.trim();
+    }
+
+    private String getElasticResponse() {
+        return """
+            {
+              "took": 538,
+              "timed_out": false,
+              "_shards": {
+                "total": 1,
+                "successful": 1,
+                "skipped": 0,
+                "failed": 0
+              },
+              "hits": {
+                "total": {
+                  "value": 4,
+                  "relation": "eq"
+                },
+                "max_score": null,
+                "hits": [
+                  {
+                    "_index": "gcp_vminstance",
+                    "_id": "central-run-349616_us-central1-a_3228267340273394036",
+                    "_score": null,
+                    "_source": {
+                      "owner": true,
+                      "_docid": "central-run-349616_us-central1-a_3228267340273394036",
+                      "docType": "vminstance",
+                      "_cspm_source": null,
+                      "_reporting_source": "gcp",
+                      "_cloudType": "gcp",
+                      "latest": true,
+                      "_entity": "true",
+                      "_entitytype": "vminstance",
+                      "_loaddate": "2024-09-27 23:14:00+0000",
+                      "name": "paladincloud-demo-vm",
+                      "_resourcename": "3228267340273394036",
+                      "_resourceid": "3228267340273394036",
+                      "tags": {
+                        "application": "coffeeapp",
+                        "environment": "test"
+                      },
+                      "sourceDisplayName": "GCP",
+                      "primaryProvider": "{\\"auto_restart\\":true,\\"can_ip_forward\\":false,\\"confidential_computing\\":false,\\"description\\":\\"\\",\\"disks\\":[{\\"id\\":\\"0\\",\\"projectId\\":\\"central-run-349616\\",\\"projectName\\":\\"Paladin Cloud\\",\\"name\\":\\"paladincloud-demo-vm\\",\\"sizeInGb\\":10,\\"type\\":\\"PERSISTENT\\",\\"autoDelete\\":true,\\"hasSha256\\":false,\\"hasKMSKeyName\\":false,\\"labels\\":null,\\"region\\":\\"\\"}],\\"emails\\":[\\"344106022091-compute@developer.gserviceaccount.com\\"],\\"id\\":3228267340273394036,\\"item_interfaces\\":[{\\"key\\":\\"enable-oslogin\\",\\"value\\":\\"true\\"}],\\"labels\\":{\\"application\\":\\"coffeeapp\\",\\"environment\\":\\"test\\"},\\"machine_type\\":\\"https://www.googleapis.com/compute/v1/projects/central-run-349616/zones/us-central1-a/machineTypes/e2-medium\\",\\"name\\":\\"paladincloud-demo-vm\\",\\"network_interfaces\\":[{\\"id\\":\\"10.128.0.32\\",\\"name\\":\\"nic0\\",\\"network\\":\\"https://www.googleapis.com/compute/v1/projects/central-run-349616/global/networks/default\\",\\"accessConfig\\":[{\\"id\\":\\"External NAT\\",\\"name\\":\\"External NAT\\",\\"natIp\\":\\"34.31.240.178\\",\\"projectName\\":\\"Paladin Cloud\\"}]}],\\"on_host_maintainence\\":\\"MIGRATE\\",\\"project_id\\":\\"central-run-349616\\",\\"project_name\\":\\"Paladin Cloud\\",\\"project_number\\":344106022091,\\"region\\":\\"us-central1-a\\",\\"scopes\\":[\\"https://www.googleapis.com/auth/devstorage.read_only\\",\\"https://www.googleapis.com/auth/logging.write\\",\\"https://www.googleapis.com/auth/monitoring.write\\",\\"https://www.googleapis.com/auth/servicecontrol\\",\\"https://www.googleapis.com/auth/service.management.readonly\\",\\"https://www.googleapis.com/auth/trace.append\\"],\\"service_accounts\\":[{\\"email\\":\\"344106022091-compute@developer.gserviceaccount.com\\",\\"emailBytes\\":{},\\"scopeList\\":[\\"https://www.googleapis.com/auth/devstorage.read_only\\",\\"https://www.googleapis.com/auth/logging.write\\",\\"https://www.googleapis.com/auth/monitoring.write\\",\\"https://www.googleapis.com/auth/servicecontrol\\",\\"https://www.googleapis.com/auth/service.management.readonly\\",\\"https://www.googleapis.com/auth/trace.append\\"]}],\\"shielded_instance_config\\":{\\"enableVtpm\\":true,\\"enableIntegrityMonitoring\\":true},\\"status\\":\\"RUNNING\\"}",
+                      "assetIdDisplayName": null,
+                      "targettypedisplayname": "VM",
+                      "targetTypeDisplayName": "VM",
+                      "accountid": "central-run-349616",
+                      "accountname": "Paladin Cloud",
+                      "discoverydate": "2024-09-27 22:28:00+0000",
+                      "firstdiscoveredon": "2024-09-27 22:28:00+0000",
+                      "tags.Environment": "test",
+                      "tags.Application": "coffeeapp",
+                      "vminstance_relations": "vminstance"
+                    },
+                    "sort": [
+                      "2024-09-27 23:14:00+0000"
+                    ]
+                  }
+                ]
+              }
+            }            """.trim();
     }
 }

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
@@ -46,7 +46,6 @@ public class AssetDTOTests {
     @Test
     void elasticResponseDeserialized() throws JsonProcessingException {
         var sampleJson = getElasticResponse();
-//        var deserialized = JsonHelper.objectMapper.readValue(sampleJson, ElasticQueryAssetResponse.class);
         var deserialized = JsonHelper.fromString(ElasticQueryAssetResponse.class, sampleJson);
         assertNotNull(deserialized);
         assertNotNull(deserialized.hits);
@@ -177,6 +176,7 @@ public class AssetDTOTests {
                   }
                 ]
               }
-            }            """.trim();
+            }
+            """.trim();
     }
 }

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
@@ -150,7 +150,7 @@ void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
                 "confidentialComputing": false,
                 "canIPForward": false,
                 "_cloudType": "gcp",
-                "tags": {},
+                "tags": { "environment": "test" },
                 "networkInterfaces": [
                     {
                         "id": "10.128.0.89",
@@ -228,7 +228,6 @@ void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
     private String getSamplePrimaryAssetDocument() {
         return """
             {
-                "owner": true,
                 "_docid": "us-central",
                 "docType": "ec2",
                 "_cspm_source": "Paladin Cloud",


### PR DESCRIPTION
Due to unnecessary filters, only a few fields were being returned by Elastic. This resulted in fields being set to null/0/false which caused all sorts of problems.

In addition
- the new style tags were added, an map of name/value pairs.
- the ElasticSearch `_id` field no longer prefixes the data source