### PR TITLE
Feature:[NEXT-204] Add and set new asset state field; set new v2 asset fields

### DIFF
--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/ApplicationModule.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/ApplicationModule.java
@@ -111,7 +111,7 @@ public class ApplicationModule {
 
     @Singleton
     @Provides
-    AssetStateHelper provideAssetStatusHelper(DatabaseHelper databaseHelper) {
+    AssetStateHelper provideAssetStateHelper(DatabaseHelper databaseHelper) {
         return new AssetStateHelper(databaseHelper);
     }
 }

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/ApplicationModule.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/ApplicationModule.java
@@ -5,6 +5,7 @@ import com.paladincloud.common.assets.AssetCountsHelper;
 import com.paladincloud.common.assets.AssetGroupStatsCollector;
 import com.paladincloud.common.assets.AssetGroups;
 import com.paladincloud.common.assets.AssetRepository;
+import com.paladincloud.common.assets.AssetStateHelper;
 import com.paladincloud.common.assets.Assets;
 import com.paladincloud.common.assets.DataSourceHelper;
 import com.paladincloud.common.assets.ElasticAssetRepository;
@@ -56,8 +57,8 @@ public class ApplicationModule {
 
     @Singleton
     @Provides
-    Assets provideAssets(AssetRepository assetRepository, AssetTypes assetTypes, MapperRepository mapperRepository, DatabaseHelper databaseHelper) {
-        return new Assets(assetRepository, assetTypes, mapperRepository, databaseHelper);
+    Assets provideAssets(AssetRepository assetRepository, AssetTypes assetTypes, MapperRepository mapperRepository, DatabaseHelper databaseHelper, AssetStateHelper assetStateHelper) {
+        return new Assets(assetRepository, assetTypes, mapperRepository, databaseHelper, assetStateHelper);
     }
 
     @Singleton
@@ -106,5 +107,11 @@ public class ApplicationModule {
     @Provides
     AssetRepository provideAssetRepository(ElasticSearchHelper elasticSearch) {
         return new ElasticAssetRepository(elasticSearch);
+    }
+
+    @Singleton
+    @Provides
+    AssetStateHelper provideAssetStatusHelper(DatabaseHelper databaseHelper) {
+        return new AssetStateHelper(databaseHelper);
     }
 }

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/AssetDocumentFields.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/AssetDocumentFields.java
@@ -5,10 +5,12 @@ package com.paladincloud.common;
  */
 public interface AssetDocumentFields {
 
-    String CSPM_SOURCE = "_cspm_source";
     String REPORTING_SOURCE = "_reporting_source";
     String NAME = "name";
     String ASSET_ID_DISPLAY_NAME = "assetIdDisplayName";
+
+    String ASSET_STATE = "_assetState";
+
     /**
      * This is the legacy field for the target type display name; the field name is
      * all lowercase and is being replaced with `targetTypeDisplayName`. Until the

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/AssetDocumentFields.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/AssetDocumentFields.java
@@ -5,46 +5,66 @@ package com.paladincloud.common;
  */
 public interface AssetDocumentFields {
 
-    String REPORTING_SOURCE = "_reporting_source";
-    String NAME = "name";
+    String LEGACY_NAME = "name";
     String ASSET_ID_DISPLAY_NAME = "assetIdDisplayName";
 
     String ASSET_STATE = "_assetState";
 
-    /**
-     * This is the legacy field for the target type display name; the field name is
-     * all lowercase and is being replaced with `targetTypeDisplayName`. Until the
-     * transition is complete, both fields will exist simultaneously.
-     */
-    String LEGACY_TARGET_TYPE_DISPLAY_NAME = "targettypedisplayname";
-    String TARGET_TYPE_DISPLAY_NAME = "targetTypeDisplayName";
+    String LEGACY_TARGET_TYPE_DISPLAY_NAME = "targetTypeDisplayName";
+    String LEGACY_ENTITY_TYPE_DISPLAY_NAME = "targettypedisplayname";
     String SOURCE_DISPLAY_NAME = "sourceDisplayName";
     String PRIMARY_PROVIDER = "primaryProvider";
 
-    String DOC_TYPE = "docType";
+    String DOC_TYPE = "_docType";
+    String LEGACY_DOC_TYPE = "docType";
 
-    String DISCOVERY_DATE = "discoverydate";
-    String FIRST_DISCOVERED = "firstdiscoveredon";
-    String LOAD_DATE = "_loaddate";
+    String LAST_DISCOVERY_DATE = "_lastDiscoveryDate";
+    String LEGACY_LAST_DISCOVERY_DATE = "discoverydate";
 
-    String ACCOUNT_ID = "accountid";
-    String ACCOUNT_NAME = "accountname";
+    String FIRST_DISCOVERY_DATE = "_firstDiscoveryDate";
+    String LEGACY_FIRST_DISCOVERY_DATE = "firstdiscoveredon";
+
+    String LOAD_DATE = "_loadDate";
+    String LEGACY_LOAD_DATE = "_loaddate";
+
+    String ACCOUNT_ID = "account_id";
+    String LEGACY_ACCOUNT_ID = "accountid";
+
+    String ACCOUNT_NAME = "account_name";
+    String LEGACY_ACCOUNT_NAME = "accountname";
+
     String PROJECT_ID = "projectId";
     String PROJECT_NAME = "projectName";
     String SUBSCRIPTION = "subscription";
     String SUBSCRIPTION_NAME = "subscriptionName";
 
-    String CLOUD_TYPE = "_cloudType";
-    String DOC_ID = "_docid";
-    String ENTITY = "_entity";
-    String ENTITY_TYPE = "_entitytype";
+    String SOURCE = "source";
+    String LEGACY_SOURCE = "_cloudType";
+
+    String REGION = "region";
+
+    String DOC_ID = "_docId";
+    String LEGACY_DOC_ID = "_docid";
+
+    String IS_ENTITY = "_isEntity";
+    String LEGACY_IS_ENTITY = "_entity";
+
+    String ENTITY_TYPE = "_entityType";
+    String LEGACY_ENTITY_TYPE = "_entitytype";
+
+    String ENTITY_TYPE_DISPLAY_NAME = "_entityTypeDisplayName";
     String RELATIONS = "_relations";
 
-    String LATEST = "latest";
+    String IS_LATEST = "_isLatest";
+    String LEGACY_IS_LATEST = "latest";
 
     String RESOURCE_GROUP_NAME = "resourceGroupName";
-    String RESOURCE_ID = "_resourceid";
-    String RESOURCE_NAME = "_resourcename";
+
+    String RESOURCE_ID = "resource_id";
+    String LEGACY_RESOURCE_ID = "_resourceid";
+
+    String RESOURCE_NAME = "resource_name";
+    String LEGACY_RESOURCE_NAME = "_resourcename";
 
     String TAGS = "tags";
 

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -20,6 +20,14 @@ public class AssetDTO {
      */
     private final Map<String, Object> additionalProperties = new HashMap<>();
 
+    // ---------------------------------------------------------------------------------------------
+    // RESERVED FIELDS
+    // ---------------------------------------------------------------------------------------------
+    // NOTE: There are legacy fields for some of these values; these fields are being replaced
+    // for the Asset 2.0 document model. These reserved fields will start with an underscore and
+    // be lowerCamelCase (_likeThis).
+    // Legacy fields will have the word legacy in them and will eventually be removed.
+
     /**
      * This is the unique id for the asset, which depends on the source & type as well as the unique
      * id for the instance. This unique id the same for the lifetime of the asset.
@@ -34,36 +42,50 @@ public class AssetDTO {
     @JsonProperty(AssetDocumentFields.DOC_TYPE)
     private String docType;
 
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.REPORTING_SOURCE)
-    private String reportingSource;     // Qualys, Tenable, gcp, aws, azure
-
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.CLOUD_TYPE)
-    private String cloudType;
-
-    @Getter
-    @Setter
-    @JsonProperty(AssetDocumentFields.LATEST)
-    private boolean latest;
-
     @Getter
     @Setter
     @JsonProperty(AssetDocumentFields.ASSET_STATE)
     private AssetState assetState;
 
-    @Getter
-    @Setter
-    @JsonProperty(AssetDocumentFields.ENTITY)
-    @JsonFormat(shape = Shape.STRING)
-    private boolean entity;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.ENTITY_TYPE)
     private String entityType;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.ENTITY_TYPE_DISPLAY_NAME)
+    private String entityTypeDisplayName;
+
+    @Getter
+    @Setter
+    @JsonProperty(AssetDocumentFields.IS_ENTITY)
+    private boolean isEntity;
+
+    @Getter
+    @Setter
+    @JsonProperty(AssetDocumentFields.IS_LATEST)
+    private boolean isLatest;
+
+    /**
+     * Managed by the asset-shipper; this is the earliest discovery date there are records for. The
+     * format is "yyyy-MM-dd HH:mm:00Z"
+     */
+    @Setter
+    @Getter
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+    @JsonProperty(AssetDocumentFields.FIRST_DISCOVERY_DATE)
+    private ZonedDateTime firstDiscoveryDate;
+
+    /**
+     * The most recent date the primary source discovered this asset; this is set in the mapper. The
+     * format is "yyyy-MM-dd HH:mm:00Z"
+     */
+    @Setter
+    @Getter
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+    @JsonProperty(AssetDocumentFields.LAST_DISCOVERY_DATE)
+    private ZonedDateTime lastDiscoveryDate;
 
     /**
      * The date the item was loaded/saved into the repository: The format is "yyyy-MM-dd HH:mm:00Z"
@@ -74,15 +96,70 @@ public class AssetDTO {
     @JsonProperty(AssetDocumentFields.LOAD_DATE)
     private ZonedDateTime loadDate;
 
+
+    // ---------------------------------------------------------------------------------------------
+    // LEGACY RESERVED FIELDS
+    // ---------------------------------------------------------------------------------------------
     @Setter
     @Getter
-    @JsonProperty(AssetDocumentFields.NAME)
-    private String name;
+    @JsonProperty(AssetDocumentFields.LEGACY_DOC_ID)
+    private String legacyDocId;
 
     @Setter
     @Getter
-    @JsonProperty(AssetDocumentFields.RESOURCE_NAME)
-    private String resourceName;
+    @JsonProperty(AssetDocumentFields.LEGACY_DOC_TYPE)
+    private String legacyDocType;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_ENTITY_TYPE)
+    private String legacyEntityType;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_ENTITY_TYPE_DISPLAY_NAME)
+    private String legacyEntityTypeDisplayName;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_TARGET_TYPE_DISPLAY_NAME)
+    private String legacyTargetTypeDisplayName;
+
+    @Getter
+    @Setter
+    @JsonProperty(AssetDocumentFields.LEGACY_IS_ENTITY)
+    @JsonFormat(shape = Shape.STRING)
+    private boolean legacyIsEntity;
+
+    @Getter
+    @Setter
+    @JsonProperty(AssetDocumentFields.LEGACY_IS_LATEST)
+    private boolean legacyIsLatest;
+
+    @Setter
+    @Getter
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+    @JsonProperty(AssetDocumentFields.LEGACY_LAST_DISCOVERY_DATE)
+    private ZonedDateTime legacyLastDiscoveryDate;
+
+    @Setter
+    @Getter
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+    @JsonProperty(AssetDocumentFields.LEGACY_LOAD_DATE)
+    private ZonedDateTime legacyLoadDate;
+
+    @Setter
+    @Getter
+    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+    @JsonProperty(AssetDocumentFields.LEGACY_FIRST_DISCOVERY_DATE)
+    private ZonedDateTime legacyFirstDiscoveryDate;
+
+    // ---------------------------------------------------------------------------------------------
+    // TOP LEVEL FIELDS
+    // ---------------------------------------------------------------------------------------------
+    // NOTE: There are legacy fields for some of these values; these fields are being replaced
+    // for the Asset 2.0 document model. These reserved fields are snake case (like_this).
+    // Legacy fields will have the word legacy in them and will eventually be removed.
 
     @Setter
     @Getter
@@ -91,38 +168,19 @@ public class AssetDTO {
 
     @Setter
     @Getter
-    @JsonProperty(AssetDocumentFields.TAGS)
-    private Map<String, String> tags;
+    @JsonProperty(AssetDocumentFields.RESOURCE_NAME)
+    private String resourceName;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.SOURCE)
+    private String source;
+
 
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.SOURCE_DISPLAY_NAME)
     private String sourceDisplayName;
-
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.PRIMARY_PROVIDER)
-    private String primaryProvider;
-
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.ASSET_ID_DISPLAY_NAME)
-    private String assetIdDisplayName;
-
-    /**
-     * This is the legacy field for the target type display name; the field name is
-     * all lowercase and is being replaced with `targetTypeDisplayName`. Until the
-     * transition is complete, both fields will exist simultaneously.
-     */
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.LEGACY_TARGET_TYPE_DISPLAY_NAME)
-    private String legacyTargetTypeDisplayName;
-
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.TARGET_TYPE_DISPLAY_NAME)
-    private String targetTypeDisplayName;
 
     @Setter
     @Getter
@@ -134,30 +192,66 @@ public class AssetDTO {
     @JsonProperty(AssetDocumentFields.ACCOUNT_NAME)
     private String accountName;
 
-    /**
-     * The date the primary source discovered this asset; this is set in the mapper. The format is
-     * "yyyy-MM-dd HH:mm:00Z"
-     */
     @Setter
     @Getter
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
-    @JsonProperty(AssetDocumentFields.DISCOVERY_DATE)
-    private ZonedDateTime discoveryDate;
+    @JsonProperty(AssetDocumentFields.REGION)
+    private String region;
 
-    /**
-     * Managed by the asset-shipper; this is the earliest discovery date there are records for. The
-     * format is "yyyy-MM-dd HH:mm:00Z"
-     */
     @Setter
     @Getter
-    @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
-    @JsonProperty(AssetDocumentFields.FIRST_DISCOVERED)
-    private ZonedDateTime firstDiscoveryDate;
+    @JsonProperty(AssetDocumentFields.TAGS)
+    private Map<String, String> tags;
+
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.PRIMARY_PROVIDER)
+    private String primaryProvider;
+
+
+    // ---------------------------------------------------------------------------------------------
+    // LEGACY TOP LEVEL FIELDS
+    // ---------------------------------------------------------------------------------------------
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_RESOURCE_ID)
+    private String legacyResourceId;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_NAME)
+    private String legacyName;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_RESOURCE_NAME)
+    private String legacyResourceName;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_SOURCE)
+    private String legacySource;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_ACCOUNT_ID)
+    private String legacyAccountId;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.LEGACY_ACCOUNT_NAME)
+    private String legacyAccountName;
+
+    // ---------------------------------------------------------------------------------------------
+    // Fields of uncertain usage; it's not clear if these continue to be used; these should be
+    // either proper top-level fields or legacy fields or be removed.
+
+    // NOTE: This is only set for Azure
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.ASSET_ID_DISPLAY_NAME)
+    private String assetIdDisplayName;
+
 
     /**
-     * This is used by the JSON parser when it can't find a matching field. It's needed for
-     * tags & relations
-     * @param key - key
+     * This is used by the JSON parser when it can't find a matching field. It's needed for tags &
+     * relations
+     *
+     * @param key   - key
      * @param value - value
      */
     @JsonAnySetter
@@ -172,6 +266,7 @@ public class AssetDTO {
     public void addType(String key, Object value) {
         additionalProperties.put(key, value);
     }
+
     /**
      * This property provides access to the remaining fields in this document. Set non-common
      * properties via {@link #addRelation(String, String)} and {@link #addType(String, Object)}.

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -36,11 +36,6 @@ public class AssetDTO {
 
     @Setter
     @Getter
-    @JsonProperty(AssetDocumentFields.CSPM_SOURCE)
-    private String cspmSource;          // Usually PaladinCloud, but can be Wiz and others
-
-    @Setter
-    @Getter
     @JsonProperty(AssetDocumentFields.REPORTING_SOURCE)
     private String reportingSource;     // Qualys, Tenable, gcp, aws, azure
 
@@ -53,6 +48,11 @@ public class AssetDTO {
     @Setter
     @JsonProperty(AssetDocumentFields.LATEST)
     private boolean latest;
+
+    @Getter
+    @Setter
+    @JsonProperty(AssetDocumentFields.ASSET_STATE)
+    private AssetState assetState;
 
     @Getter
     @Setter

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -42,7 +42,7 @@ public class AssetDocumentHelper {
     // Once all components are updated, the additional mapper fields will be removed from the
     // top-level asset document
     static private Set<String> assetFields = new HashSet<>(
-        List.of(MAPPER_RAW_DATA, AssetDocumentFields.CSPM_SOURCE,
+        List.of(MAPPER_RAW_DATA,
             AssetDocumentFields.REPORTING_SOURCE, AssetDocumentFields.NAME,
             AssetDocumentFields.ASSET_ID_DISPLAY_NAME,
             AssetDocumentFields.LEGACY_TARGET_TYPE_DISPLAY_NAME,
@@ -76,6 +76,8 @@ public class AssetDocumentHelper {
     private List<Map<String, Object>> tags;
     @NonNull
     private Function<String, String> accountIdToNameFn;
+    @NonNull
+    private AssetState assetState;
     private String resourceNameField;
 
 
@@ -124,7 +126,6 @@ public class AssetDocumentHelper {
             entry(AssetDocumentFields.ACCOUNT_NAME, v -> dto.setAccountName(v.toString())),
             entry(AssetDocumentFields.CLOUD_TYPE,
                 v -> dto.setCloudType(v.toString().toLowerCase())),
-            entry(AssetDocumentFields.CSPM_SOURCE, v -> dto.setCspmSource(v.toString())),
             entry(AssetDocumentFields.DISCOVERY_DATE,
                 v -> dto.setDiscoveryDate(TimeHelper.parseDiscoveryDate(v.toString()))),
             entry(AssetDocumentFields.NAME, v -> dto.setName(v.toString())),
@@ -144,6 +145,7 @@ public class AssetDocumentHelper {
         dto.setDocId(docId);
         dto.setEntity(true);
         dto.setReportingSource(dataSource);
+        dto.setAssetState(assetState);
 
         // Set common asset properties
         dto.setEntityType(type);
@@ -221,13 +223,12 @@ public class AssetDocumentHelper {
             data.getOrDefault(AssetDocumentFields.SOURCE_DISPLAY_NAME, "").toString());
 
         // One time only, existing assets in ElasticSearch must be updated to include new fields
-        if (StringUtils.isBlank(dto.getCspmSource())) {
-            dto.setCspmSource(data.getOrDefault(AssetDocumentFields.CSPM_SOURCE, "").toString());
-        }
         if (StringUtils.isBlank(dto.getReportingSource())) {
             dto.setReportingSource(
                 data.getOrDefault(AssetDocumentFields.REPORTING_SOURCE, "").toString());
         }
+
+        dto.setAssetState(assetState);
 
         // Update all fields the user has control over.
         if (data.containsKey(AssetDocumentFields.NAME)) {

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetState.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetState.java
@@ -1,0 +1,17 @@
+package com.paladincloud.common.assets;
+
+import lombok.Getter;
+
+public enum AssetState {
+    MANAGED("Managed"),
+    UNMANAGED("Unmanaged"),
+    SUSPICIOUS("Suspicious"),
+    RECONCILING("Reconciling");
+
+    @Getter
+    final private String name;
+
+    private AssetState(String name) {
+        this.name = name;
+    }
+}

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetStateHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetStateHelper.java
@@ -1,0 +1,46 @@
+package com.paladincloud.common.assets;
+
+import com.paladincloud.common.aws.DatabaseHelper;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class AssetStateHelper {
+
+    private final DatabaseHelper databaseHelper;
+
+    private final Map<String, Map<String, Integer>> sourceTypeMap = new HashMap<>();
+
+    @Inject
+    public AssetStateHelper(DatabaseHelper databaseHelper) {
+        this.databaseHelper = databaseHelper;
+    }
+
+    public AssetState get(String dataSource, String assetType) {
+        var typeCountMap = getSourceTypeMap(dataSource);
+        if (typeCountMap == null) {
+            return AssetState.SUSPICIOUS;
+        }
+        if (typeCountMap.getOrDefault(assetType, 0).equals(0)) {
+            return AssetState.UNMANAGED;
+        }
+        return AssetState.MANAGED;
+    }
+
+    private Map<String, Integer> getSourceTypeMap(String dataSource) {
+        if (!sourceTypeMap.containsKey(dataSource)) {
+            var typeCountMap = new HashMap<String, Integer>();
+            databaseHelper.executeQuery(
+                    STR."SELECT targetType,count(*) FROM pacmandata.cf_PolicyTable WHERE assetGroup = '\{dataSource}' AND status = 'ENABLED' GROUP BY targetType")
+                .forEach(row -> {
+                    var type = row.get("targetType");
+                    var count = row.get("count(*)");
+                    typeCountMap.put(type, Integer.parseInt(count));
+                });
+            sourceTypeMap.put(dataSource, typeCountMap);
+        }
+        return sourceTypeMap.get(dataSource);
+    }
+}

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetStateHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/AssetStateHelper.java
@@ -20,9 +20,6 @@ public class AssetStateHelper {
 
     public AssetState get(String dataSource, String assetType) {
         var typeCountMap = getSourceTypeMap(dataSource);
-        if (typeCountMap == null) {
-            return AssetState.SUSPICIOUS;
-        }
         if (typeCountMap.getOrDefault(assetType, 0).equals(0)) {
             return AssetState.UNMANAGED;
         }

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/Assets.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/assets/Assets.java
@@ -38,14 +38,17 @@ public class Assets {
     private final AssetRepository assetRepository;
     private final MapperRepository mapperRepository;
     private final DatabaseHelper databaseHelper;
+    private final AssetStateHelper assetStateHelper;
 
     @Inject
     public Assets(AssetRepository assetRepository, AssetTypes assetTypes,
-        MapperRepository mapperRepository, DatabaseHelper databaseHelper) {
+        MapperRepository mapperRepository, DatabaseHelper databaseHelper,
+        AssetStateHelper assetStateHelper) {
         this.assetRepository = assetRepository;
         this.assetTypes = assetTypes;
         this.mapperRepository = mapperRepository;
         this.databaseHelper = databaseHelper;
+        this.assetStateHelper = assetStateHelper;
     }
 
     private static String assetsPathPrefix(String dataSource) {
@@ -107,7 +110,7 @@ public class Assets {
                         .idField(idColumn).docIdFields(docIdFields).dataSource(dataSource)
                         .isCloud(isCloudDataSource)
                         .displayName(displayName).tags(tags).type(type)
-                        .accountIdToNameFn(this::accountIdToName);
+                        .accountIdToNameFn(this::accountIdToName).assetState(assetStateHelper.get(dataSource, type));
                     var mergeResponse = MergeAssets.process(assetCreator.build(), existingAssets,
                         latestAssets);
                     LOGGER.info(

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/search/ElasticSearchHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/search/ElasticSearchHelper.java
@@ -209,7 +209,9 @@ public class ElasticSearchHelper {
                 endPoint, payLoad);
             if (response.hits != null && response.hits.hits != null) {
                 for (var hit : response.hits.hits) {
-                    results.put(hit.source.getDocId(), hit.source);
+                    // NOTE: This needs to be the legacy doc id in order for matches of pre-migrated
+                    // assets.
+                    results.put(hit.source.getLegacyDocId(), hit.source);
                 }
             }
             return response.scrollId;

--- a/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/util/MapHelper.java
+++ b/assets-management/services/asset-sender/src/main/java/com/paladincloud/common/util/MapHelper.java
@@ -54,4 +54,14 @@ public class MapHelper {
             throw new JobException("Error converting map to json string", e);
         }
     }
+
+    public static Object getFirstOrDefault(Map<String, ?> map, List<String> keys, Object defaultValue) {
+        for (String key : keys) {
+            var value = map.get(key);
+            if (value != null) {
+                return value;
+            }
+        }
+        return defaultValue;
+    }
 }

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.paladincloud.common.AssetDocumentFields;
 import com.paladincloud.common.assets.AssetDocumentHelper;
+import com.paladincloud.common.assets.AssetState;
 import com.paladincloud.common.util.JsonHelper;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -29,6 +30,7 @@ public class AssetDocumentHelperTests {
             .tags(List.of())
             .type("ec2")
             .accountIdToNameFn( (_) -> null)
+            .assetState(AssetState.MANAGED)
             .build();
     }
 
@@ -82,7 +84,6 @@ public class AssetDocumentHelperTests {
         AssetDocumentHelper helper = getHelper("gcp", "id");
         helper.updateFrom(mappedAsMap, dto);
 
-        assertEquals("Paladin Cloud", dto.getCspmSource());
         assertEquals("gcp", dto.getReportingSource());
     }
 
@@ -93,7 +94,6 @@ void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
         var dto = helper.createFrom(mappedAsMap);
         assertNotNull(dto);
 
-        assertEquals("Paladin Cloud", dto.getCspmSource());
         assertEquals("secondary", dto.getReportingSource());
     }
 

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
@@ -19,11 +19,11 @@ import org.junit.jupiter.api.Test;
  */
 public class AssetDocumentHelperTests {
 
-    static private AssetDocumentHelper getHelper(String dataSource, String idField) {
+    static private AssetDocumentHelper getHelper(String dataSource, String idField, String resourceNameField) {
         return AssetDocumentHelper.builder()
             .loadDate(ZonedDateTime.now())
             .idField(idField)
-            .docIdFields(List.of("accountid", "region", "instanceid"))
+            .docIdFields(List.of("accountid", "region", idField))
             .dataSource(dataSource)
             .isCloud(true)
             .displayName("ec2")
@@ -31,13 +31,37 @@ public class AssetDocumentHelperTests {
             .type("ec2")
             .accountIdToNameFn( (_) -> null)
             .assetState(AssetState.MANAGED)
+            .resourceNameField(resourceNameField)
             .build();
     }
 
     @Test
-    void primaryDtoIsFullyPopulated() throws JsonProcessingException {
-        AssetDocumentHelper helper = getHelper("gcp", "id");
-        var mapperData = JsonHelper.mapFromString(getSamplePrimaryMapperDocument());
+    void dtoIsPopulatedFromV2Mapper() throws JsonProcessingException {
+        AssetDocumentHelper helper = getHelper("gcp", "resource_id", "resource_name");
+        var mapperData = JsonHelper.mapFromString(getV2PrimaryMapperDocument());
+        var dto = helper.createFrom(mapperData);
+
+        var dtoAsMap = JsonHelper.mapFromString(JsonHelper.objectMapper.writeValueAsString(dto));
+        var expectedMap = JsonHelper.mapFromString(getSamplePrimaryAssetDocument());
+
+        assertNotNull(dto);
+        assertNotNull(dtoAsMap.get(AssetDocumentFields.LEGACY_LOAD_DATE));
+        assertFalse(dtoAsMap.get(AssetDocumentFields.LEGACY_LOAD_DATE).toString().isBlank());
+        assertNotNull(dtoAsMap.get(AssetDocumentFields.PRIMARY_PROVIDER));
+        assertEquals(mapperData.get("rawData"), dtoAsMap.get(AssetDocumentFields.PRIMARY_PROVIDER));
+
+        // Ensure each value in the sample asset exists in the serialized/deserialized instance
+        expectedMap.forEach((key, value) -> {
+            assertTrue(dtoAsMap.containsKey(key), key);
+            assertEquals(value, dtoAsMap.get(key),
+                STR."\{key} value differs. expected=\{value} actual=\{dtoAsMap.get(key)}");
+        });
+    }
+
+    @Test
+    void primaryDtoIsFullyPopulatedFromLegacyMapper() throws JsonProcessingException {
+        AssetDocumentHelper helper = getHelper("gcp", "_resource_id", "_resource_name");
+        var mapperData = JsonHelper.mapFromString(getLegacyPrimaryMapperDocument());
 
         var dto = helper.createFrom(mapperData);
 
@@ -45,8 +69,8 @@ public class AssetDocumentHelperTests {
         var expectedMap = JsonHelper.mapFromString(getSamplePrimaryAssetDocument());
 
         assertNotNull(dto);
-        assertNotNull(dtoAsMap.get(AssetDocumentFields.LOAD_DATE));
-        assertFalse(dtoAsMap.get(AssetDocumentFields.LOAD_DATE).toString().isBlank());
+        assertNotNull(dtoAsMap.get(AssetDocumentFields.LEGACY_LOAD_DATE));
+        assertFalse(dtoAsMap.get(AssetDocumentFields.LEGACY_LOAD_DATE).toString().isBlank());
         assertNotNull(dtoAsMap.get(AssetDocumentFields.PRIMARY_PROVIDER));
         assertEquals(mapperData.get("rawData"), dtoAsMap.get(AssetDocumentFields.PRIMARY_PROVIDER));
 
@@ -54,22 +78,22 @@ public class AssetDocumentHelperTests {
         expectedMap.forEach((key, value) -> {
                 assertTrue(dtoAsMap.containsKey(key), key);
                 assertEquals(value, dtoAsMap.get(key),
-                    STR."\{key} value differs. expected=\{value} actual=\{dtoAsMap.get(key)}");
+                    STR."'\{key}' value differs. expected=\{value} actual=\{dtoAsMap.get(key)}");
         });
     }
 
     @Test
     void dtoIsUpdated() throws JsonProcessingException {
-        var mappedAsMap = JsonHelper.mapFromString(getSamplePrimaryMapperDocument());
-        var dto = getHelper("gcp", "id").createFrom(mappedAsMap);
+        var mappedAsMap = JsonHelper.mapFromString(getLegacyPrimaryMapperDocument());
+        var dto = getHelper("gcp", "_resource_id", null).createFrom(mappedAsMap);
 
-        mappedAsMap.put(AssetDocumentFields.ACCOUNT_NAME, "new account name");
+        mappedAsMap.put(AssetDocumentFields.LEGACY_ACCOUNT_NAME, "new account name");
 
-        AssetDocumentHelper helper = getHelper("gcp", "id");
+        AssetDocumentHelper helper = getHelper("gcp", "_resource_id", null);
         helper.updateFrom(mappedAsMap, dto);
 
-        assertEquals("new account name", dto.getAccountName());
-        assertTrue(dto.isLatest());
+        assertEquals("new account name", dto.getLegacyAccountName());
+        assertTrue(dto.isLegacyIsLatest());
     }
 
     /**
@@ -78,30 +102,45 @@ public class AssetDocumentHelperTests {
      */
     @Test
     void updatedDtoHasNewFields() throws JsonProcessingException {
-        var mappedAsMap = JsonHelper.mapFromString(getSamplePrimaryMapperDocument());
-        var dto = getHelper("gcp", "id").createFrom(mappedAsMap);
+        var mappedAsMap = JsonHelper.mapFromString(getLegacyPrimaryMapperDocument());
+        var dto = getHelper("gcp", "_resource_id", null).createFrom(mappedAsMap);
 
-        AssetDocumentHelper helper = getHelper("gcp", "id");
+        AssetDocumentHelper helper = getHelper("gcp", "_resource_id", null);
         helper.updateFrom(mappedAsMap, dto);
-
-        assertEquals("gcp", dto.getReportingSource());
     }
 
     @Test
 void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
-        AssetDocumentHelper helper = getHelper("secondary", "_resourceid");
+        AssetDocumentHelper helper = getHelper("secondary", "_resourceid", null);
         var mappedAsMap = JsonHelper.mapFromString(getSampleSecondaryDocument());
         var dto = helper.createFrom(mappedAsMap);
         assertNotNull(dto);
 
-        assertEquals("secondary", dto.getReportingSource());
+//        assertEquals("secondary", dto.getReportingSource());
     }
 
-    private String getSamplePrimaryMapperDocument() {
+    private String getV2PrimaryMapperDocument() {
         return """
             {
-                "_cspm_source": "Paladin Cloud",
-                "_reporting_source": "aws",
+                "rawData": "{\\"auto_restart\\":true,\\"can_ip_forward\\":false,\\"confidential_computing\\":false,\\"description\\":\\"\\",\\"disks\\":[{\\"id\\":\\"0\\",\\"projectId\\":\\"xyz\\",\\"projectName\\":\\"Project\\",\\"name\\":\\"instance-abc\\",\\"sizeInGb\\":50,\\"type\\":\\"PERSISTENT\\",\\"autoDelete\\":true,\\"hasSha256\\":false,\\"hasKMSKeyName\\":false,\\"labels\\":null,\\"region\\":\\"\\"}],\\"emails\\":[\\"fubar@developer.gserviceaccount.com\\"],\\"id\\":17,\\"item_interfaces\\":[{\\"key\\":\\"enable-oslogin\\",\\"value\\":\\"true\\"}],\\"labels\\":{},\\"machine_type\\":\\"https://www.googleapis.com/compute/v1/projects/xyz/zones/z/machineTypes/e2-standard-2\\",\\"name\\":\\"instance-abc\\",\\"network_interfaces\\":[{\\"id\\":\\"100.128.100.189\\",\\"name\\":\\"nic0\\",\\"network\\":\\"https://www.googleapis.com/compute/v1/projects/xyz/global/networks/default\\",\\"accessConfig\\":[{\\"id\\":\\"External NAT\\",\\"name\\":\\"External NAT\\",\\"natIp\\":null,\\"projectName\\":\\"Project\\"}]}],\\"on_host_maintainence\\":\\"MIGRATE\\",\\"project_id\\":\\"xyz\\",\\"project_name\\":\\"Project\\",\\"project_number\\":344106022091,\\"region\\":\\"r\\",\\"scopes\\":[\\"https://www.googleapis.com/auth/devstorage.read_only\\",\\"https://www.googleapis.com/auth/logging.write\\",\\"https://www.googleapis.com/auth/monitoring.write\\",\\"https://www.googleapis.com/auth/servicecontrol\\",\\"https://www.googleapis.com/auth/service.management.readonly\\",\\"https://www.googleapis.com/auth/trace.append\\"],\\"service_accounts\\":[{\\"email\\":\\"fubar@developer.gserviceaccount.com\\",\\"emailBytes\\":{},\\"scopeList\\":[\\"https://www.googleapis.com/auth/devstorage.read_only\\",\\"https://www.googleapis.com/auth/logging.write\\",\\"https://www.googleapis.com/auth/monitoring.write\\",\\"https://www.googleapis.com/auth/servicecontrol\\",\\"https://www.googleapis.com/auth/service.management.readonly\\",\\"https://www.googleapis.com/auth/trace.append\\"]}],\\"shielded_instance_config\\":{\\"enableVtpm\\":true,\\"enableIntegrityMonitoring\\":true},\\"status\\":\\"TERMINATED\\"}",
+                "_lastDiscoveryDate": "2024-09-05 14:57:00+0000",
+                "resource_id": "17",
+                "resource_name": "instance-abc",
+                "account_id": "abc",
+                "source": "gcp",
+                "source_display_name": "GCP",
+                "_entityType": "vminstance",
+                "_entityTypeDisplayName": "VM",
+                "region": "us-central",
+                "reporting_source": "gcp",
+                "tags": { "environment": "test" },
+                "projectId": "xyz"
+            }""".trim();
+    }
+
+    private String getLegacyPrimaryMapperDocument() {
+        return """
+            {
                 "rawData": "{\\"auto_restart\\":true,\\"can_ip_forward\\":false,\\"confidential_computing\\":false,\\"description\\":\\"\\",\\"disks\\":[{\\"id\\":\\"0\\",\\"projectId\\":\\"xyz\\",\\"projectName\\":\\"Project\\",\\"name\\":\\"instance-abc\\",\\"sizeInGb\\":50,\\"type\\":\\"PERSISTENT\\",\\"autoDelete\\":true,\\"hasSha256\\":false,\\"hasKMSKeyName\\":false,\\"labels\\":null,\\"region\\":\\"\\"}],\\"emails\\":[\\"fubar@developer.gserviceaccount.com\\"],\\"id\\":17,\\"item_interfaces\\":[{\\"key\\":\\"enable-oslogin\\",\\"value\\":\\"true\\"}],\\"labels\\":{},\\"machine_type\\":\\"https://www.googleapis.com/compute/v1/projects/xyz/zones/z/machineTypes/e2-standard-2\\",\\"name\\":\\"instance-abc\\",\\"network_interfaces\\":[{\\"id\\":\\"100.128.100.189\\",\\"name\\":\\"nic0\\",\\"network\\":\\"https://www.googleapis.com/compute/v1/projects/xyz/global/networks/default\\",\\"accessConfig\\":[{\\"id\\":\\"External NAT\\",\\"name\\":\\"External NAT\\",\\"natIp\\":null,\\"projectName\\":\\"Project\\"}]}],\\"on_host_maintainence\\":\\"MIGRATE\\",\\"project_id\\":\\"xyz\\",\\"project_name\\":\\"Project\\",\\"project_number\\":344106022091,\\"region\\":\\"r\\",\\"scopes\\":[\\"https://www.googleapis.com/auth/devstorage.read_only\\",\\"https://www.googleapis.com/auth/logging.write\\",\\"https://www.googleapis.com/auth/monitoring.write\\",\\"https://www.googleapis.com/auth/servicecontrol\\",\\"https://www.googleapis.com/auth/service.management.readonly\\",\\"https://www.googleapis.com/auth/trace.append\\"],\\"service_accounts\\":[{\\"email\\":\\"fubar@developer.gserviceaccount.com\\",\\"emailBytes\\":{},\\"scopeList\\":[\\"https://www.googleapis.com/auth/devstorage.read_only\\",\\"https://www.googleapis.com/auth/logging.write\\",\\"https://www.googleapis.com/auth/monitoring.write\\",\\"https://www.googleapis.com/auth/servicecontrol\\",\\"https://www.googleapis.com/auth/service.management.readonly\\",\\"https://www.googleapis.com/auth/trace.append\\"]}],\\"shielded_instance_config\\":{\\"enableVtpm\\":true,\\"enableIntegrityMonitoring\\":true},\\"status\\":\\"TERMINATED\\"}",
                 "autoRestart": true,
                 "sourceDisplayName": "GCP",
@@ -165,7 +204,8 @@ void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
                     }
                 ],
                 "name": "instance-abc",
-                "id": "17",
+                "_resource_id": "17",
+                "_resource_name": "instance-abc",
                 "region": "us-central",
                 "projectId": "xyz",
                 "items": [
@@ -191,8 +231,6 @@ void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
     private String getSampleSecondaryDocument() {
         return """
             {
-                "_cspm_source": "Paladin Cloud",
-                "_reporting_source": "secondary",
                 "_resourceid": "i-76",
                 "_resourcename": "ABD-DEF",
                 "_cloudType": "aws",
@@ -226,16 +264,14 @@ void secondaryDtoIsFullyPopulated() throws JsonProcessingException {
     private String getSamplePrimaryAssetDocument() {
         return """
             {
-                "_docid": "us-central",
+                "_docid": "us-central_17",
                 "docType": "ec2",
-                "_cspm_source": "Paladin Cloud",
-                "_reporting_source": "gcp",
                 "_cloudType": "gcp",
                 "latest": true,
                 "_entity": "true",
                 "_entitytype": "ec2",
                 "name": "instance-abc",
-                "_resourcename": "17",
+                "_resourcename": "instance-abc",
                 "_resourceid": "17",
                 "sourceDisplayName": "GCP",
                 "assetIdDisplayName": null,

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/MergeAssetsTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/MergeAssetsTests.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import com.paladincloud.common.AssetDocumentFields;
 import com.paladincloud.common.assets.AssetDTO;
 import com.paladincloud.common.assets.AssetDocumentHelper;
+import com.paladincloud.common.assets.AssetState;
 import com.paladincloud.common.assets.MergeAssets;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -36,7 +37,6 @@ public class MergeAssetsTests {
             doc.put("id", id);
             doc.put(AssetDocumentFields.NAME, STR."name \{id}");
             doc.put(AssetDocumentFields.DISCOVERY_DATE, "2024-07-21 13:13:00+0000");
-            doc.put(AssetDocumentFields.CSPM_SOURCE, "Paladin Cloud");
             doc.put(AssetDocumentFields.REPORTING_SOURCE, "aws");
             latest.add(doc);
         });
@@ -55,6 +55,7 @@ public class MergeAssetsTests {
             .tags(List.of())
             .type(type)
             .accountIdToNameFn( (_) -> null)
+            .assetState(AssetState.MANAGED)
             .build();
     }
 

--- a/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/MergeAssetsTests.java
+++ b/assets-management/services/asset-sender/src/test/java/com/paladincloud/commons/assets/MergeAssetsTests.java
@@ -23,9 +23,9 @@ public class MergeAssetsTests {
         Map<String, AssetDTO> existing = new HashMap<>();
         ids.forEach(id -> {
             var asset = new AssetDTO();
-            asset.setDocId(id);
+            asset.setLegacyDocId(id);
 
-            existing.put(asset.getDocId(), asset);
+            existing.put(asset.getLegacyDocId(), asset);
         });
         return existing;
     }
@@ -35,16 +35,16 @@ public class MergeAssetsTests {
         ids.forEach(id -> {
             Map<String, Object> doc = new HashMap<>();
             doc.put("id", id);
-            doc.put(AssetDocumentFields.NAME, STR."name \{id}");
-            doc.put(AssetDocumentFields.DISCOVERY_DATE, "2024-07-21 13:13:00+0000");
-            doc.put(AssetDocumentFields.REPORTING_SOURCE, "aws");
+            doc.put(AssetDocumentFields.RESOURCE_NAME, STR."name \{id}");
+            doc.put(AssetDocumentFields.LAST_DISCOVERY_DATE, "2024-07-21 13:13:00+0000");
+//            doc.put(AssetDocumentFields.REPORTING_SOURCE, "aws");
             latest.add(doc);
         });
         return latest;
     }
 
     static private AssetDocumentHelper getHelper(ZonedDateTime startTime, String dataSource,
-        String type) {
+        String type, String resourceNameField) {
         return AssetDocumentHelper.builder()
             .loadDate(startTime)
             .idField("id")
@@ -56,6 +56,7 @@ public class MergeAssetsTests {
             .type(type)
             .accountIdToNameFn( (_) -> null)
             .assetState(AssetState.MANAGED)
+            .resourceNameField(resourceNameField)
             .build();
     }
 
@@ -65,7 +66,7 @@ public class MergeAssetsTests {
         var existing = createExisting(List.of());
         var latest = createLatest(List.of("q13"));
 
-        var creator = getHelper(ZonedDateTime.now(), "test3", "ec3");
+        var creator = getHelper(ZonedDateTime.now(), "test3", "ec3", "resource_name");
         var merger = MergeAssets.process(creator, existing, latest);
 
         assertEquals(Set.of(), merger.getRemovedAssets().keySet());
@@ -79,13 +80,13 @@ public class MergeAssetsTests {
         var existing = createExisting(List.of());
         var latest = createLatest(List.of("q13"));
 
-        var creator = getHelper(ZonedDateTime.now(), "test", "ec2");
+        var creator = getHelper(ZonedDateTime.now(), "test", "ec2", "resource_name");
         var merger = MergeAssets.process(creator, existing, latest);
         assertEquals(Set.of("q13"), merger.getNewAssets().keySet());
 
         var created = merger.getNewAssets().get("q13");
         assertNotNull(created);
-        assertEquals("q13", created.getDocId());
+        assertEquals("q13", created.getLegacyDocId());
     }
 
     // Verify no longer present assets are identified properly
@@ -94,7 +95,7 @@ public class MergeAssetsTests {
         var existing = createExisting(List.of("q13"));
         var latest = createLatest(List.of());
 
-        var creator = getHelper(ZonedDateTime.now(), "test", "ec2");
+        var creator = getHelper(ZonedDateTime.now(), "test", "ec2", "resource_name");
         var merger = MergeAssets.process(creator, existing, latest);
 
         assertEquals(Set.of("q13"), merger.getRemovedAssets().keySet());
@@ -108,7 +109,7 @@ public class MergeAssetsTests {
         var existing = createExisting(List.of("q13"));
         var latest = createLatest(List.of("q13"));
 
-        var creator = getHelper(ZonedDateTime.now(), "test", "ec2");
+        var creator = getHelper(ZonedDateTime.now(), "test", "ec2", "resource_name");
         var merger = MergeAssets.process(creator, existing, latest);
 
         assertEquals(Set.of(), merger.getRemovedAssets().keySet());
@@ -119,14 +120,14 @@ public class MergeAssetsTests {
     @Test
     void updatedAreModified() {
         var existing = createExisting(List.of("q13"));
-        existing.get("q13").setName("old name");
+        existing.get("q13").setResourceName("old name");
         var latest = createLatest(List.of("q13"));
 
-        var creator = getHelper(ZonedDateTime.now(), "test", "ec2");
+        var creator = getHelper(ZonedDateTime.now(), "test", "ec2", "resource_name");
         MergeAssets.process(creator, existing, latest);
         var updated = existing.get("q13");
         assertNotNull(updated);
-        assertEquals("name q13", updated.getName());
+        assertEquals("name q13", updated.getResourceName());
     }
 
     @Test
@@ -134,12 +135,12 @@ public class MergeAssetsTests {
         var existing = createExisting(List.of("q13"));
         var latest = createLatest(List.of());
 
-        var creator = getHelper(ZonedDateTime.now(), "test", "ec2");
+        var creator = getHelper(ZonedDateTime.now(), "test", "ec2", "resource_name");
         var merger = MergeAssets.process(creator, existing, latest);
 
         var removed = merger.getRemovedAssets().get("q13");
         assertNotNull(removed);
 
-        assertFalse(removed.isLatest());
+        assertFalse(removed.isLegacyIsLatest());
     }
 }


### PR DESCRIPTION
Add the new asset state field and set it; currently it's either managed or unmanaged and suspicious will be set when opinions are processed.
I also removed the CSPM Source as we've gone a different direction and this has never been used.

I've added the asset model v2 fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `AssetState` enum with states: MANAGED, UNMANAGED, SUSPICIOUS, and RECONCILING.
	- Added `AssetStateHelper` to manage asset states effectively.

- **Changes**
	- Updated asset-related classes to incorporate `AssetState`.
	- Removed the `CSPM_SOURCE` field from asset documents, streamlining asset management.
	- Enhanced backward compatibility with legacy fields and naming conventions.

- **Bug Fixes**
	- Adjusted tests to reflect the removal of `CSPM_SOURCE` and ensure proper asset state handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->