### PR TITLE
fix/NEXT-262 - Enable Common Service for Asset Subsystem by Making Assume Role Optional

### DIFF
--- a/ui-asset-management/api/svc-asset-details/extension/clients/asset_details_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/asset_details_client.go
@@ -17,8 +17,8 @@ type AssetDetailsClient struct {
 }
 
 func NewAssetDetailsClient(ctx context.Context, config *Configuration) *AssetDetailsClient {
-	dynamodbClient, _ := NewDynamoDBClient(ctx, config.AssumeRoleArn, config.Region, config.TenantConfigOutputTable, config.TenantTablePartitionKey)
-	secretsClient, _ := NewSecretsClient(ctx, config.AssumeRoleArn, config.Region)
+	dynamodbClient, _ := NewDynamoDBClient(ctx, config.UseAssumeRole, config.AssumeRoleArn, config.Region, config.TenantConfigOutputTable, config.TenantTablePartitionKey)
+	secretsClient, _ := NewSecretsClient(ctx, config.UseAssumeRole, config.AssumeRoleArn, config.Region)
 
 	return &AssetDetailsClient{
 		configuration:       config,

--- a/ui-asset-management/api/svc-asset-details/extension/clients/config_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/config_client.go
@@ -25,6 +25,7 @@ import (
 
 type Configuration struct {
 	EnableExtension         bool
+	UseAssumeRole           bool
 	AssumeRoleArn           string
 	Region                  string
 	TenantConfigOutputTable string
@@ -41,14 +42,23 @@ func LoadConfigurationDetails() *Configuration {
 		enableExtension = true
 	}
 
+	// We only want to use assume role if config dynamodb and secrets manager is in a different account
+	assumeRoleArn := os.Getenv("ASSUME_ROLE_ARN")
+	useAssumeRole := false
+	if assumeRoleArn != "" {
+		fmt.Printf("using ASSUME_ROLE_ARN to assume role: %s\n", assumeRoleArn)
+		useAssumeRole = true
+	}
+
+	// Load the region and other configuration details and fail if not set
 	region := getEnvVariable("REGION")
-	assumeRoleArn := getEnvVariable("ASSUME_ROLE_ARN")
 	tenantConfigOutputTable := getEnvVariable("TENANT_CONFIG_OUTPUT_TABLE")
 	tenantTablePartitionKey := getEnvVariable("TENANT_TABLE_PARTITION_KEY")
 	secretIdPrefix := getEnvVariable("SECRET_NAME_PREFIX")
 
 	return &Configuration{
 		EnableExtension:         enableExtension,
+		UseAssumeRole:           useAssumeRole,
 		AssumeRoleArn:           assumeRoleArn,
 		Region:                  region,
 		TenantConfigOutputTable: tenantConfigOutputTable,

--- a/ui-asset-management/api/svc-asset-details/extension/clients/config_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/config_client.go
@@ -48,6 +48,8 @@ func LoadConfigurationDetails() *Configuration {
 	if assumeRoleArn != "" {
 		fmt.Printf("using ASSUME_ROLE_ARN to assume role: %s\n", assumeRoleArn)
 		useAssumeRole = true
+	} else {
+		fmt.Println("ASSUME_ROLE_ARN environment variable not set, defaulting to false")
 	}
 
 	// Load the region and other configuration details and fail if not set

--- a/ui-asset-management/api/svc-asset-details/extension/clients/dynamodb_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/dynamodb_client.go
@@ -66,7 +66,7 @@ func NewDynamoDBClient(ctx context.Context, useAssumeRole bool, assumeRoleArn, r
 		svc = dynamodb.NewFromConfig(cfg)
 	}
 
-	fmt.Println("initialized dynamodb client with assumed role")
+	fmt.Println("initialized dynamodb client")
 	return &DynamodbClient{
 		region:                  region,
 		client:                  svc,

--- a/ui-asset-management/api/svc-asset-details/extension/clients/dynamodb_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/dynamodb_client.go
@@ -37,30 +37,34 @@ type DynamodbClient struct {
 }
 
 // NewDynamoDBClient inits a DynamoDB session to be used throughout the services
-func NewDynamoDBClient(ctx context.Context, assumeRoleArn, region, tenantConfigOutputTable, tenantTablePartitionKey string) (*DynamodbClient, error) {
-
+func NewDynamoDBClient(ctx context.Context, useAssumeRole bool, assumeRoleArn, region, tenantConfigOutputTable, tenantTablePartitionKey string) (*DynamodbClient, error) {
 	// Load the default AWS configuration
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS config: %+v", err)
 	}
 
-	// Create an STS client
-	stsClient := sts.NewFromConfig(cfg)
+	var svc *dynamodb.Client
+	if useAssumeRole {
+		// Create an STS client
+		stsClient := sts.NewFromConfig(cfg)
 
-	// Assume the role using STS
-	creds := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleArn, func(o *stscreds.AssumeRoleOptions) {
-		o.RoleSessionName = "DynamoDBSession"
-	})
+		// Assume the role using STS
+		creds := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleArn, func(o *stscreds.AssumeRoleOptions) {
+			o.RoleSessionName = "DynamoDBSession"
+		})
 
-	// Create a new AWS configuration with the assumed role credentials
-	assumedCfg := aws.Config{
-		Credentials: aws.NewCredentialsCache(creds),
-		Region:      region,
+		// Create a new AWS configuration with the assumed role credentials
+		assumedCfg := aws.Config{
+			Credentials: aws.NewCredentialsCache(creds),
+			Region:      region,
+		}
+
+		// Initialize the DynamoDB client with the assumed role credentials
+		svc = dynamodb.NewFromConfig(assumedCfg)
+	} else {
+		svc = dynamodb.NewFromConfig(cfg)
 	}
-
-	// Initialize the DynamoDB client with the assumed role credentials
-	svc := dynamodb.NewFromConfig(assumedCfg)
 
 	fmt.Println("initialized dynamodb client with assumed role")
 	return &DynamodbClient{

--- a/ui-asset-management/api/svc-asset-details/extension/clients/dynamodb_client_test.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/dynamodb_client_test.go
@@ -25,12 +25,13 @@ func TestNewDynamoDBClient(t *testing.T) {
 	ctx := context.Background()
 
 	tenantId := "tenant_id"
+	useAssumeRole := true
 	assumeRole := "arn:aws:iam::{accountID}:role/{roleName}"
 	region := "us-east-1"
 	tenantConfigTable := "tenant-output"
 	tenantConfigTablePartitionKey := "tenant_id"
 
-	client, err := NewDynamoDBClient(ctx, assumeRole, region, tenantConfigTable, tenantConfigTablePartitionKey)
+	client, err := NewDynamoDBClient(ctx, useAssumeRole, assumeRole, region, tenantConfigTable, tenantConfigTablePartitionKey)
 	if err != nil {
 		t.Fatalf("Failed to create DynamoDB client: %v", err)
 	}

--- a/ui-asset-management/api/svc-asset-details/extension/clients/rds_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/rds_client.go
@@ -79,7 +79,7 @@ func (r *RdsClient) CreateNewClient(ctx context.Context, tenantId string) *sql.D
 func (r *RdsClient) FetchMandatoryTags(ctx context.Context, tenantId string) ([]models.Tag, error) {
 	dbClient := r.CreateNewClient(ctx, tenantId)
 
-	fmt.Println("Getting Plugins List from RDS")
+	fmt.Println("getting mandatory tags from rds")
 	query := `
 		select opt.optionName as tagName
                 from pac_v2_ui_options opt join pac_v2_ui_filters fil on opt.filterId= fil.filterId 

--- a/ui-asset-management/api/svc-asset-details/extension/clients/rds_client_test.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/rds_client_test.go
@@ -25,12 +25,13 @@ import (
 func TestNewRDSClient(t *testing.T) {
 	ctx := context.Background()
 
-	tenantId := "tenant_id"
-	assumeRole := "arn:aws:iam::{accountID}:role/{roleName}"
+	tenantId := "9c35f4eb-b880-4e63-bcef-ed47569d9408"
+	useAssumeRole := false
+	assumeRoleArn := ""
 	region := "us-east-1"
-	secretIdPrefix := "paladincloud/secret/`"
+	secretIdPrefix := "paladincloud/secret/"
 
-	secretsClient, _ := NewSecretsClient(ctx, assumeRole, region)
+	secretsClient, _ := NewSecretsClient(ctx, useAssumeRole, assumeRoleArn, region)
 
 	client := NewRdsClient(secretsClient, secretIdPrefix)
 	response, err := client.FetchMandatoryTags(ctx, tenantId)

--- a/ui-asset-management/api/svc-asset-details/extension/clients/secrets_client_test.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/secrets_client_test.go
@@ -18,7 +18,6 @@ package clients
 
 import (
 	"context"
-	"os"
 	"testing"
 )
 
@@ -26,12 +25,11 @@ func TestNewSecretsClient(t *testing.T) {
 	t.Run("NewSecretsClient", func(t *testing.T) {
 		ctx := context.Background()
 
-		assumeRole := os.Getenv("AWS_ASSUME_ROLE_ARN")
-		if assumeRole == "" {
-			t.Fatal("AWS_ASSUME_ROLE_ARN environment variable not set")
-		}
+		useAssumeRole := false
+		assumeRoleArn := ""
+		region := "us-east-1"
 
-		_, err := NewSecretsClient(ctx, assumeRole, "us-east-1")
+		_, err := NewSecretsClient(ctx, useAssumeRole, assumeRoleArn, region)
 		if err != nil {
 			t.Errorf("Error loading AWS config: %v", err)
 		}

--- a/ui-asset-management/api/svc-asset-details/extension/main.go
+++ b/ui-asset-management/api/svc-asset-details/extension/main.go
@@ -77,7 +77,7 @@ func startMain(configuration *clients.Configuration) {
 			fmt.Errorf("unable to register extension: %+v", err)
 		}
 
-		fmt.Println("client registered:", res)
+		fmt.Println("client registered:", *res)
 
 		// Will block until shutdown event is received or cancelled via the context.
 		processEvents(ctx)

--- a/ui-asset-management/api/svc-asset-details/extension/main_test.go
+++ b/ui-asset-management/api/svc-asset-details/extension/main_test.go
@@ -26,6 +26,8 @@ func TestStartMain(t *testing.T) {
 	t.Run("main", func(t *testing.T) {
 		config := &clients.Configuration{
 			EnableExtension:         false,
+			UseAssumeRole:           false,
+			AssumeRoleArn:           "",
 			Region:                  "us-east-1",
 			TenantConfigOutputTable: "tenant-output",
 			TenantTablePartitionKey: "tenant_id",

--- a/ui-asset-management/api/svc-asset-network-rules/extension/clients/asset_network_rules_client.go
+++ b/ui-asset-management/api/svc-asset-network-rules/extension/clients/asset_network_rules_client.go
@@ -13,7 +13,7 @@ type AssetNetworkRulesClient struct {
 }
 
 func NewAssetNetworkRulesClient(ctx context.Context, config *Configuration) *AssetNetworkRulesClient {
-	dynamodbClient, _ := NewDynamoDBClient(ctx, config.AssumeRoleArn, config.Region, config.TenantConfigOutputTable, config.TenantTablePartitionKey)
+	dynamodbClient, _ := NewDynamoDBClient(ctx, config.UseAssumeRole, config.AssumeRoleArn, config.Region, config.TenantConfigOutputTable, config.TenantTablePartitionKey)
 	return &AssetNetworkRulesClient{elasticSearchClient: NewElasticSearchClient(dynamodbClient)}
 }
 

--- a/ui-asset-management/api/svc-asset-network-rules/extension/clients/config_client.go
+++ b/ui-asset-management/api/svc-asset-network-rules/extension/clients/config_client.go
@@ -25,6 +25,7 @@ import (
 
 type Configuration struct {
 	EnableExtension         bool
+	UseAssumeRole           bool
 	AssumeRoleArn           string
 	Region                  string
 	TenantConfigOutputTable string
@@ -41,14 +42,23 @@ func LoadConfigurationDetails() *Configuration {
 		enableExtension = true
 	}
 
+	// We only want to use assume role if config dynamodb and secrets manager is in a different account
+	assumeRoleArn := os.Getenv("ASSUME_ROLE_ARN")
+	useAssumeRole := false
+	if assumeRoleArn != "" {
+		fmt.Printf("using ASSUME_ROLE_ARN to assume role: %s\n", assumeRoleArn)
+		useAssumeRole = true
+	}
+
+	// Load the region and other configuration details and fail if not set
 	region := getEnvVariable("REGION")
-	assumeRoleArn := getEnvVariable("ASSUME_ROLE_ARN")
 	tenantConfigOutputTable := getEnvVariable("TENANT_CONFIG_OUTPUT_TABLE")
 	tenantTablePartitionKey := getEnvVariable("TENANT_TABLE_PARTITION_KEY")
 	secretIdPrefix := getEnvVariable("SECRET_NAME_PREFIX")
 
 	return &Configuration{
 		EnableExtension:         enableExtension,
+		UseAssumeRole:           useAssumeRole,
 		AssumeRoleArn:           assumeRoleArn,
 		Region:                  region,
 		TenantConfigOutputTable: tenantConfigOutputTable,

--- a/ui-asset-management/api/svc-asset-network-rules/extension/clients/config_client.go
+++ b/ui-asset-management/api/svc-asset-network-rules/extension/clients/config_client.go
@@ -48,6 +48,8 @@ func LoadConfigurationDetails() *Configuration {
 	if assumeRoleArn != "" {
 		fmt.Printf("using ASSUME_ROLE_ARN to assume role: %s\n", assumeRoleArn)
 		useAssumeRole = true
+	} else {
+		fmt.Println("ASSUME_ROLE_ARN environment variable not set, defaulting to false")
 	}
 
 	// Load the region and other configuration details and fail if not set

--- a/ui-asset-management/api/svc-asset-network-rules/extension/clients/dynamodb_client.go
+++ b/ui-asset-management/api/svc-asset-network-rules/extension/clients/dynamodb_client.go
@@ -66,7 +66,7 @@ func NewDynamoDBClient(ctx context.Context, useAssumeRole bool, assumeRoleArn, r
 		svc = dynamodb.NewFromConfig(cfg)
 	}
 
-	fmt.Println("initialized dynamodb client with assumed role")
+	fmt.Println("initialized dynamodb client")
 	return &DynamodbClient{
 		region:                  region,
 		client:                  svc,

--- a/ui-asset-management/api/svc-asset-network-rules/extension/clients/dynamodb_client.go
+++ b/ui-asset-management/api/svc-asset-network-rules/extension/clients/dynamodb_client.go
@@ -37,30 +37,34 @@ type DynamodbClient struct {
 }
 
 // NewDynamoDBClient inits a DynamoDB session to be used throughout the services
-func NewDynamoDBClient(ctx context.Context, assumeRoleArn, region, tenantConfigOutputTable, tenantTablePartitionKey string) (*DynamodbClient, error) {
-
+func NewDynamoDBClient(ctx context.Context, useAssumeRole bool, assumeRoleArn, region, tenantConfigOutputTable, tenantTablePartitionKey string) (*DynamodbClient, error) {
 	// Load the default AWS configuration
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS config: %+v", err)
 	}
 
-	// Create an STS client
-	stsClient := sts.NewFromConfig(cfg)
+	var svc *dynamodb.Client
+	if useAssumeRole {
+		// Create an STS client
+		stsClient := sts.NewFromConfig(cfg)
 
-	// Assume the role using STS
-	creds := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleArn, func(o *stscreds.AssumeRoleOptions) {
-		o.RoleSessionName = "DynamoDBSession"
-	})
+		// Assume the role using STS
+		creds := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleArn, func(o *stscreds.AssumeRoleOptions) {
+			o.RoleSessionName = "DynamoDBSession"
+		})
 
-	// Create a new AWS configuration with the assumed role credentials
-	assumedCfg := aws.Config{
-		Credentials: aws.NewCredentialsCache(creds),
-		Region:      region,
+		// Create a new AWS configuration with the assumed role credentials
+		assumedCfg := aws.Config{
+			Credentials: aws.NewCredentialsCache(creds),
+			Region:      region,
+		}
+
+		// Initialize the DynamoDB client with the assumed role credentials
+		svc = dynamodb.NewFromConfig(assumedCfg)
+	} else {
+		svc = dynamodb.NewFromConfig(cfg)
 	}
-
-	// Initialize the DynamoDB client with the assumed role credentials
-	svc := dynamodb.NewFromConfig(assumedCfg)
 
 	fmt.Println("initialized dynamodb client with assumed role")
 	return &DynamodbClient{

--- a/ui-asset-management/api/svc-asset-violations/extension/clients/asset_violations_client.go
+++ b/ui-asset-management/api/svc-asset-violations/extension/clients/asset_violations_client.go
@@ -31,8 +31,8 @@ type AssetViolationsClient struct {
 }
 
 func NewAssetViolationsClient(ctx context.Context, config *Configuration) *AssetViolationsClient {
-	dynamodbClient, _ := NewDynamoDBClient(ctx, config.AssumeRoleArn, config.Region, config.TenantConfigOutputTable, config.TenantTablePartitionKey)
-	secretsClient, _ := NewSecretsClient(ctx, config.AssumeRoleArn, config.Region)
+	dynamodbClient, _ := NewDynamoDBClient(ctx, config.UseAssumeRole, config.AssumeRoleArn, config.Region, config.TenantConfigOutputTable, config.TenantTablePartitionKey)
+	secretsClient, _ := NewSecretsClient(ctx, config.UseAssumeRole, config.AssumeRoleArn, config.Region)
 
 	return &AssetViolationsClient{
 		elasticSearchClient: NewElasticSearchClient(dynamodbClient),

--- a/ui-asset-management/api/svc-asset-violations/extension/clients/config_client.go
+++ b/ui-asset-management/api/svc-asset-violations/extension/clients/config_client.go
@@ -25,6 +25,7 @@ import (
 
 type Configuration struct {
 	EnableExtension         bool
+	UseAssumeRole           bool
 	AssumeRoleArn           string
 	Region                  string
 	TenantConfigOutputTable string
@@ -41,14 +42,23 @@ func LoadConfigurationDetails() *Configuration {
 		enableExtension = true
 	}
 
+	// We only want to use assume role if config dynamodb and secrets manager is in a different account
+	assumeRoleArn := os.Getenv("ASSUME_ROLE_ARN")
+	useAssumeRole := false
+	if assumeRoleArn != "" {
+		fmt.Printf("using ASSUME_ROLE_ARN to assume role: %s\n", assumeRoleArn)
+		useAssumeRole = true
+	}
+
+	// Load the region and other configuration details and fail if not set
 	region := getEnvVariable("REGION")
-	assumeRoleArn := getEnvVariable("ASSUME_ROLE_ARN")
 	tenantConfigOutputTable := getEnvVariable("TENANT_CONFIG_OUTPUT_TABLE")
 	tenantTablePartitionKey := getEnvVariable("TENANT_TABLE_PARTITION_KEY")
 	secretIdPrefix := getEnvVariable("SECRET_NAME_PREFIX")
 
 	return &Configuration{
 		EnableExtension:         enableExtension,
+		UseAssumeRole:           useAssumeRole,
 		AssumeRoleArn:           assumeRoleArn,
 		Region:                  region,
 		TenantConfigOutputTable: tenantConfigOutputTable,

--- a/ui-asset-management/api/svc-asset-violations/extension/clients/config_client.go
+++ b/ui-asset-management/api/svc-asset-violations/extension/clients/config_client.go
@@ -48,6 +48,8 @@ func LoadConfigurationDetails() *Configuration {
 	if assumeRoleArn != "" {
 		fmt.Printf("using ASSUME_ROLE_ARN to assume role: %s\n", assumeRoleArn)
 		useAssumeRole = true
+	} else {
+		fmt.Println("ASSUME_ROLE_ARN environment variable not set, defaulting to false")
 	}
 
 	// Load the region and other configuration details and fail if not set

--- a/ui-asset-management/api/svc-asset-violations/extension/clients/dynamodb_client.go
+++ b/ui-asset-management/api/svc-asset-violations/extension/clients/dynamodb_client.go
@@ -66,7 +66,7 @@ func NewDynamoDBClient(ctx context.Context, useAssumeRole bool, assumeRoleArn, r
 		svc = dynamodb.NewFromConfig(cfg)
 	}
 
-	fmt.Println("initialized dynamodb client with assumed role")
+	fmt.Println("initialized dynamodb client")
 	return &DynamodbClient{
 		region:                  region,
 		client:                  svc,

--- a/ui-asset-management/api/svc-asset-violations/extension/clients/dynamodb_client.go
+++ b/ui-asset-management/api/svc-asset-violations/extension/clients/dynamodb_client.go
@@ -37,30 +37,34 @@ type DynamodbClient struct {
 }
 
 // NewDynamoDBClient inits a DynamoDB session to be used throughout the services
-func NewDynamoDBClient(ctx context.Context, assumeRoleArn, region, tenantConfigOutputTable, tenantTablePartitionKey string) (*DynamodbClient, error) {
-
+func NewDynamoDBClient(ctx context.Context, useAssumeRole bool, assumeRoleArn, region, tenantConfigOutputTable, tenantTablePartitionKey string) (*DynamodbClient, error) {
 	// Load the default AWS configuration
 	cfg, err := config.LoadDefaultConfig(ctx, config.WithRegion(region))
 	if err != nil {
 		return nil, fmt.Errorf("error loading AWS config: %+v", err)
 	}
 
-	// Create an STS client
-	stsClient := sts.NewFromConfig(cfg)
+	var svc *dynamodb.Client
+	if useAssumeRole {
+		// Create an STS client
+		stsClient := sts.NewFromConfig(cfg)
 
-	// Assume the role using STS
-	creds := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleArn, func(o *stscreds.AssumeRoleOptions) {
-		o.RoleSessionName = "DynamoDBSession"
-	})
+		// Assume the role using STS
+		creds := stscreds.NewAssumeRoleProvider(stsClient, assumeRoleArn, func(o *stscreds.AssumeRoleOptions) {
+			o.RoleSessionName = "DynamoDBSession"
+		})
 
-	// Create a new AWS configuration with the assumed role credentials
-	assumedCfg := aws.Config{
-		Credentials: aws.NewCredentialsCache(creds),
-		Region:      region,
+		// Create a new AWS configuration with the assumed role credentials
+		assumedCfg := aws.Config{
+			Credentials: aws.NewCredentialsCache(creds),
+			Region:      region,
+		}
+
+		// Initialize the DynamoDB client with the assumed role credentials
+		svc = dynamodb.NewFromConfig(assumedCfg)
+	} else {
+		svc = dynamodb.NewFromConfig(cfg)
 	}
-
-	// Initialize the DynamoDB client with the assumed role credentials
-	svc := dynamodb.NewFromConfig(assumedCfg)
 
 	fmt.Println("initialized dynamodb client with assumed role")
 	return &DynamodbClient{


### PR DESCRIPTION
### Code Review Description: Enable Common Service for Asset Subsystem by Making Assume Role Optional

This update modifies the asset subsystem to support a common service architecture by making the "assume role" functionality optional. When running in a SaaS environment, the service will automatically inherit the necessary permissions to access resources like DynamoDB and Secrets Manager, provided it is assigned the appropriate IAM role permissions. 

By making the assume role optional:
- In non-SaaS environments, the system can still assume roles as needed for cross-account access.
- In SaaS environments, the service simplifies permission management by leveraging IAM roles directly, reducing the complexity of role assumption.
  
This change enhances flexibility and simplifies the deployment process in SaaS environments where the service already has direct access to the required AWS resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Introduced a new parameter `UseAssumeRole` to enhance client initialization for DynamoDB and Secrets Manager, allowing for role assumption based on configuration.
	- Improved error handling and logging for asset details and violations retrieval processes.
  
- **Bug Fixes**
	- Streamlined error handling in the `GetAssetViolations` method to avoid redundant checks.
  
- **Documentation**
	- Updated configuration loading logic to reflect changes in role assumption handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->