### PR TITLE
Feature:[NEXT-276] Make the ASSUME_ROLE_ARN an optional environment variable

### DIFF
--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/aws/RoleHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/aws/RoleHelper.java
@@ -1,6 +1,7 @@
 package com.paladincloud.common.aws;
 
 import java.util.function.Function;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
@@ -17,6 +18,10 @@ public class RoleHelper {
 
     public static <T> T runAs(String awsRegion, AwsCredentialsProvider currentCredentialsProvider, String roleArn,
         Function<AwsCredentialsProvider, T> runAsFn) {
+        if (StringUtils.isEmpty(roleArn)) {
+            return runAsFn.apply(null);
+        }
+
         LOGGER.info(STR."Assuming role: \{roleArn} in region \{awsRegion}");
         try (var stsClient = StsClient.builder().region(Region.of(awsRegion)).credentialsProvider(currentCredentialsProvider)
             .build()) {

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/config/ConfigParams.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/config/ConfigParams.java
@@ -11,8 +11,7 @@ import lombok.NonNull;
 @Builder
 public class ConfigParams {
 
-    // The role to assume to get both secrets & config from DynamoDB
-    @NonNull
+    // The role to assume to get both secrets & config from DynamoDB; this is optional
     String assumeRoleArn;
 
     // The tenantId (GUID)

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/config/ConfigService.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/config/ConfigService.java
@@ -12,6 +12,7 @@ import com.paladincloud.common.util.JsonHelper;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.secretsmanager.SecretsManagerClient;
 import software.amazon.awssdk.services.secretsmanager.model.GetSecretValueRequest;
@@ -63,10 +64,11 @@ public class ConfigService {
     private static Map<String, String> getSecretsWithRole(ConfigParams configParams) {
         return RoleHelper.runAs(configParams.awsRegion, null, configParams.assumeRoleArn,
             secretCredentialsProvider -> {
-                try (var client = SecretsManagerClient.builder()
-                    .credentialsProvider(secretCredentialsProvider)
-                    .region(Region.of(configParams.awsRegion))
-                    .build()) {
+                var builder = SecretsManagerClient.builder().region(Region.of(configParams.awsRegion));
+                if (secretCredentialsProvider != null) {
+                    builder.credentialsProvider(secretCredentialsProvider);
+                }
+                try (var client = builder.build()) {
                     var request = GetSecretValueRequest.builder()
                         .secretId(configParams.secretNamePrefix + configParams.tenantId)
                         .build();

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/jobs/JobExecutor.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/jobs/JobExecutor.java
@@ -1,6 +1,5 @@
 package com.paladincloud.common.jobs;
 
-import com.paladincloud.common.config.ConfigConstants;
 import com.paladincloud.common.config.ConfigConstants.PaladinCloud;
 import com.paladincloud.common.config.ConfigConstants.Tenant;
 import com.paladincloud.common.config.ConfigParams;
@@ -20,15 +19,17 @@ public abstract class JobExecutor {
     // The required tenant-id is specified as a job argument (which comes from an SQS event)
     private static final String TENANT_ID_JOB_ARGUMENT = "tenant_id";
 
-    // The AWS config details - these are required environment variables
+    // An optional environment variable; it'll be used if provided
     private static final String ASSUME_ROLE_ARN = "ASSUME_ROLE_ARN";
+
+    // The AWS config details - these are required environment variables
     private static final String REGION = "REGION";
     private static final String SECRET_NAME_PREFIX = "SECRET_NAME_PREFIX";
     private static final String TENANT_CONFIG_OUTPUT_TABLE = "TENANT_CONFIG_OUTPUT_TABLE";
     private static final String TENANT_TABLE_PARTITION_KEY = "TENANT_TABLE_PARTITION_KEY";
 
-    private static final List<String> requiredEnvironmentVariables = List.of(ASSUME_ROLE_ARN,
-        REGION, SECRET_NAME_PREFIX, TENANT_CONFIG_OUTPUT_TABLE,
+    private static final List<String> requiredEnvironmentVariables = List.of(REGION,
+        SECRET_NAME_PREFIX, TENANT_CONFIG_OUTPUT_TABLE,
         TENANT_TABLE_PARTITION_KEY);
 
     private static final List<String> requiredExecutorFields = List.of(TENANT_ID_JOB_ARGUMENT);


### PR DESCRIPTION
If the ASSUME_ROLE_ARN doesn't exist, no explicit assume role will be used (and the current role will be used to access secrets & dynamo)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced optional handling for the `ASSUME_ROLE_ARN` environment variable.
	- Improved client initialization for the `SecretsManagerClient` to enhance robustness.

- **Bug Fixes**
	- Corrected logging syntax for better clarity and consistency.

- **Documentation**
	- Updated comments to reflect the optional nature of the `assumeRoleArn` field and `ASSUME_ROLE_ARN` environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->