### PR TITLE
Feature:[NEXT-304] Opinions have been enriched to include the data and some dates

### DIFF
--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/assetsender/AssetDoneHandler.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/assetsender/AssetDoneHandler.java
@@ -4,15 +4,22 @@ import com.amazonaws.services.lambda.runtime.Context;
 import com.amazonaws.services.lambda.runtime.RequestHandler;
 import com.amazonaws.services.lambda.runtime.events.SQSEvent;
 import com.paladincloud.common.DaggerServerComponent;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
 
 public class AssetDoneHandler implements RequestHandler<SQSEvent, Integer> {
 
     @Override
     public Integer handleRequest(SQSEvent event, Context context) {
         var componentResolver = DaggerServerComponent.create();
+        var parser = Pattern.compile("([^\"]\\S*|\".+?\")\\s*");
         for (var message : event.getRecords()) {
-            var args = message.getBody().split(" ");
-            componentResolver.buildAssetSenderJob().run("AssetShipper", args);
+            var matches = parser.matcher(message.getBody());
+            var args = new ArrayList<String>();
+            while (matches.find()) {
+                args.add(matches.group().replace("\"", ""));
+            }
+            componentResolver.buildAssetSenderJob().run("AssetShipper", args.toArray(new String[0]));
         }
 
         return 0;

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/assetsender/AssetSenderJob.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/assetsender/AssetSenderJob.java
@@ -25,10 +25,11 @@ public class AssetSenderJob extends JobExecutor {
 
     public static final String DATA_SOURCE = "data_source";
     public static final String S3_PATH = "s3_path";
-    // These two optional arguments are provided for opinions; in that case, the reporting source
+    // These optional arguments are provided for opinions; in that case, the reporting source
     // will differ from the data source and the opinion service will be used to store the opinion.
     private static final String REPORTING_SOURCE = "reporting_source";
     private static final String REPORTING_SOURCE_SERVICE = "reporting_source_service";
+    private static final String REPORTING_SOURCE_SERVICE_DISPLAY_NAME = "reporting_source_service_display_name";
 
     private static final Logger LOGGER = LogManager.getLogger(AssetSenderJob.class);
 
@@ -66,7 +67,8 @@ public class AssetSenderJob extends JobExecutor {
         assetTypes.setupIndexAndTypes(dataSource);
         assets.process(dataSource, params.get(S3_PATH),
             params.get(REPORTING_SOURCE),
-            params.get(REPORTING_SOURCE_SERVICE));
+            params.get(REPORTING_SOURCE_SERVICE),
+            params.get(REPORTING_SOURCE_SERVICE_DISPLAY_NAME));
 
         if ("true".equalsIgnoreCase(ConfigService.get(Dev.SKIP_ASSET_COUNT))) {
             LOGGER.error("Skipping asset count");

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/AssetDocumentFields.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/AssetDocumentFields.java
@@ -57,6 +57,8 @@ public interface AssetDocumentFields {
     String ENTITY_TYPE_DISPLAY_NAME = "_entityTypeDisplayName";
     String RELATIONS = "_relations";
 
+    String IS_ACTIVE = "_isActive";
+
     String IS_LATEST = "_isLatest";
     String LEGACY_IS_LATEST = "latest";
 

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -305,11 +305,11 @@ public class AssetDTO {
         @JsonProperty("data")
         private String data;
 
-        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:00Z")
         @JsonProperty("firstScanDate")
         private ZonedDateTime firstScanDate;
 
-        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:00Z")
         @JsonProperty("lastScanDate")
         private ZonedDateTime lastScanDate;
 

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -64,6 +64,10 @@ public class AssetDTO {
     @Setter
     @JsonProperty(AssetDocumentFields.IS_LATEST)
     private Boolean isLatest;
+    @Getter
+    @Setter
+    @JsonProperty(AssetDocumentFields.IS_ACTIVE)
+    private Boolean isActive;
     /**
      * Managed by the asset-shipper; this is the earliest discovery date there are records for. The
      * format is "yyyy-MM-dd HH:mm:00Z"
@@ -308,6 +312,9 @@ public class AssetDTO {
         @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
         @JsonProperty("lastScanDate")
         private ZonedDateTime lastScanDate;
+
+        @JsonProperty("serviceName")
+        private String serviceName;
 
         @JsonProperty("deepLink")
         private String deepLink;

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -16,6 +16,25 @@ import lombok.Setter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AssetDTO {
 
+    @Getter
+    @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class OpinionItem {
+        @JsonProperty("data")
+        private String data;
+
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+        @JsonProperty("firstScanDate")
+        private ZonedDateTime firstScanDate;
+
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+        @JsonProperty("lastScanDate")
+        private ZonedDateTime lastScanDate;
+
+        @JsonProperty("deepLink")
+        private String deepLink;
+    }
+
     /**
      * Adds the given property and value to fields in this document. Get access to these properties
      * via {@link #getAdditionalProperties()}.
@@ -211,7 +230,7 @@ public class AssetDTO {
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.OPINIONS)
-    private Map<String,Map<String, String>> opinions;
+    private Map<String,Map<String, OpinionItem>> opinions;
 
 
     // ---------------------------------------------------------------------------------------------

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDTO.java
@@ -2,10 +2,13 @@ package com.paladincloud.common.assets;
 
 import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonFormat.Shape;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.paladincloud.common.AssetDocumentFields;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -16,39 +19,11 @@ import lombok.Setter;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AssetDTO {
 
-    @Getter
-    @Setter
-    @JsonInclude(JsonInclude.Include.NON_NULL)
-    public static class OpinionItem {
-        @JsonProperty("data")
-        private String data;
-
-        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
-        @JsonProperty("firstScanDate")
-        private ZonedDateTime firstScanDate;
-
-        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
-        @JsonProperty("lastScanDate")
-        private ZonedDateTime lastScanDate;
-
-        @JsonProperty("deepLink")
-        private String deepLink;
-    }
-
     /**
      * Adds the given property and value to fields in this document. Get access to these properties
      * via {@link #getAdditionalProperties()}.
      */
     private final Map<String, Object> additionalProperties = new HashMap<>();
-
-    // ---------------------------------------------------------------------------------------------
-    // RESERVED FIELDS
-    // ---------------------------------------------------------------------------------------------
-    // NOTE: There are legacy fields for some of these values; these fields are being replaced
-    // for the Asset 2.0 document model. These reserved fields will start with an underscore and
-    // be lowerCamelCase (_likeThis).
-    // Legacy fields will have the word legacy in them and will eventually be removed.
-
     /**
      * This is the unique id for the asset, which depends on the source & type as well as the unique
      * id for the instance. This unique id the same for the lifetime of the asset.
@@ -57,37 +32,38 @@ public class AssetDTO {
     @Getter
     @JsonProperty(AssetDocumentFields.DOC_ID)
     private String docId;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.DOC_TYPE)
     private String docType;
 
+    // ---------------------------------------------------------------------------------------------
+    // RESERVED FIELDS
+    // ---------------------------------------------------------------------------------------------
+    // NOTE: There are legacy fields for some of these values; these fields are being replaced
+    // for the Asset 2.0 document model. These reserved fields will start with an underscore and
+    // be lowerCamelCase (_likeThis).
+    // Legacy fields will have the word legacy in them and will eventually be removed.
     @Getter
     @Setter
     @JsonProperty(AssetDocumentFields.ASSET_STATE)
     private AssetState assetState;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.ENTITY_TYPE)
     private String entityType;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.ENTITY_TYPE_DISPLAY_NAME)
     private String entityTypeDisplayName;
-
     @Getter
     @Setter
     @JsonProperty(AssetDocumentFields.IS_ENTITY)
     private Boolean isEntity;
-
     @Getter
     @Setter
     @JsonProperty(AssetDocumentFields.IS_LATEST)
     private Boolean isLatest;
-
     /**
      * Managed by the asset-shipper; this is the earliest discovery date there are records for. The
      * format is "yyyy-MM-dd HH:mm:00Z"
@@ -97,7 +73,6 @@ public class AssetDTO {
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
     @JsonProperty(AssetDocumentFields.FIRST_DISCOVERY_DATE)
     private ZonedDateTime firstDiscoveryDate;
-
     /**
      * The most recent date the primary source discovered this asset; this is set in the mapper. The
      * format is "yyyy-MM-dd HH:mm:00Z"
@@ -107,7 +82,6 @@ public class AssetDTO {
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
     @JsonProperty(AssetDocumentFields.LAST_SCAN_DATE)
     private ZonedDateTime lastScanDate;
-
     /**
      * The date the item was loaded/saved into the repository: The format is "yyyy-MM-dd HH:mm:00Z"
      */
@@ -116,8 +90,6 @@ public class AssetDTO {
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
     @JsonProperty(AssetDocumentFields.LOAD_DATE)
     private ZonedDateTime loadDate;
-
-
     // ---------------------------------------------------------------------------------------------
     // LEGACY RESERVED FIELDS
     // ---------------------------------------------------------------------------------------------
@@ -125,55 +97,54 @@ public class AssetDTO {
     @Getter
     @JsonProperty(AssetDocumentFields.LEGACY_DOC_ID)
     private String legacyDocId;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.LEGACY_DOC_TYPE)
     private String legacyDocType;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.LEGACY_ENTITY_TYPE)
     private String legacyEntityType;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.LEGACY_ENTITY_TYPE_DISPLAY_NAME)
     private String legacyEntityTypeDisplayName;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.LEGACY_TARGET_TYPE_DISPLAY_NAME)
     private String legacyTargetTypeDisplayName;
-
     @Getter
     @Setter
     @JsonProperty(AssetDocumentFields.LEGACY_IS_ENTITY)
     @JsonFormat(shape = Shape.STRING)
     private Boolean legacyIsEntity;
-
     @Getter
     @Setter
     @JsonProperty(AssetDocumentFields.LEGACY_IS_LATEST)
     private Boolean legacyIsLatest;
-
     @Setter
     @Getter
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
     @JsonProperty(AssetDocumentFields.LEGACY_LAST_SCAN_DATE)
     private ZonedDateTime legacyLastScanDate;
-
     @Setter
     @Getter
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
     @JsonProperty(AssetDocumentFields.LEGACY_LOAD_DATE)
     private ZonedDateTime legacyLoadDate;
-
     @Setter
     @Getter
     @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
     @JsonProperty(AssetDocumentFields.LEGACY_FIRST_DISCOVERY_DATE)
     private ZonedDateTime legacyFirstDiscoveryDate;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.RESOURCE_ID)
+    private String resourceId;
+    @Setter
+    @Getter
+    @JsonProperty(AssetDocumentFields.RESOURCE_NAME)
+    private String resourceName;
 
     // ---------------------------------------------------------------------------------------------
     // TOP LEVEL FIELDS
@@ -181,57 +152,39 @@ public class AssetDTO {
     // NOTE: There are legacy fields for some of these values; these fields are being replaced
     // for the Asset 2.0 document model. These reserved fields are snake case (like_this).
     // Legacy fields will have the word legacy in them and will eventually be removed.
-
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.RESOURCE_ID)
-    private String resourceId;
-
-    @Setter
-    @Getter
-    @JsonProperty(AssetDocumentFields.RESOURCE_NAME)
-    private String resourceName;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.SOURCE)
     private String source;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.SOURCE_DISPLAY_NAME)
     private String sourceDisplayName;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.ACCOUNT_ID)
     private String accountId;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.ACCOUNT_NAME)
     private String accountName;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.REGION)
     private String region;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.TAGS)
     private Map<String, String> tags;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.PRIMARY_PROVIDER)
     private String primaryProvider;
-
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.OPINIONS)
-    private Map<String,Map<String, OpinionItem>> opinions;
-
+    @JsonUnwrapped
+    private OpinionCollection opinions;
 
     // ---------------------------------------------------------------------------------------------
     // LEGACY TOP LEVEL FIELDS
@@ -264,17 +217,11 @@ public class AssetDTO {
     @Getter
     @JsonProperty(AssetDocumentFields.LEGACY_ACCOUNT_NAME)
     private String legacyAccountName;
-
-    // ---------------------------------------------------------------------------------------------
-    // Fields of uncertain usage; it's not clear if these continue to be used; these should be
-    // either proper top-level fields or legacy fields or be removed.
-
     // NOTE: This is only set for Azure
     @Setter
     @Getter
     @JsonProperty(AssetDocumentFields.ASSET_ID_DISPLAY_NAME)
     private String assetIdDisplayName;
-
 
     /**
      * This is used by the JSON parser when it can't find a matching field. It's needed for tags &
@@ -285,8 +232,14 @@ public class AssetDTO {
      */
     @JsonAnySetter
     private void addAdditionalProperty(String key, Object value) {
-        additionalProperties.put(key, value);
+        if (!key.equals(AssetDocumentFields.OPINIONS)) {
+            additionalProperties.put(key, value);
+        }
     }
+
+    // ---------------------------------------------------------------------------------------------
+    // Fields of uncertain usage; it's not clear if these continue to be used; these should be
+    // either proper top-level fields or legacy fields or be removed.
 
     public void addRelation(String key, String value) {
         additionalProperties.put(key, value);
@@ -303,5 +256,60 @@ public class AssetDTO {
     @JsonAnyGetter
     public Map<String, Object> getAdditionalProperties() {
         return additionalProperties;
+    }
+
+    @JsonSerialize(as = OpinionCollection.class)
+    @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+    public static class OpinionCollection {
+
+        private final Map<String, Map<String, OpinionItem>> opinions = new HashMap<>();
+
+        public void setOpinion(String reportingSource, String reportingService,
+            OpinionItem opinionItem) {
+            opinions.computeIfAbsent(reportingSource, k -> new HashMap<>())
+                .put(reportingService, opinionItem);
+        }
+
+        public boolean hasOpinions() {
+            return !opinions.isEmpty();
+        }
+
+        public void removeOpinion(String reportingSource, String reportingService) {
+            var sourceOpinions = opinions.get(reportingSource);
+            if (sourceOpinions != null) {
+                sourceOpinions.remove(reportingService);
+                if (sourceOpinions.isEmpty()) {
+                    opinions.remove(reportingSource);
+                }
+            }
+        }
+
+        public OpinionItem getSourceAndServiceOpinion(String reportingSource, String reportingService) {
+            var sourceOpinions = opinions.get(reportingSource);
+            if (sourceOpinions != null) {
+                return sourceOpinions.get(reportingService);
+            }
+            return new OpinionItem();
+        }
+    }
+
+    @Getter
+    @Setter
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class OpinionItem {
+
+        @JsonProperty("data")
+        private String data;
+
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+        @JsonProperty("firstScanDate")
+        private ZonedDateTime firstScanDate;
+
+        @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd HH:mm:00Z")
+        @JsonProperty("lastScanDate")
+        private ZonedDateTime lastScanDate;
+
+        @JsonProperty("deepLink")
+        private String deepLink;
     }
 }

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -239,9 +239,9 @@ public class AssetDocumentHelper {
             opinionItem.setServiceName(reportingSourceServiceDisplayName);
         }
         withValue(data, List.of(MapperFields.FIRST_SCAN_DATE),
-            v -> opinionItem.setFirstScanDate(TimeHelper.parseISO860Date(v.toString())));
+            v -> opinionItem.setFirstScanDate(TimeHelper.parseISO8601Date(v.toString())));
         withStringValue(data, List.of(MapperFields.LAST_SCAN_DATE),
-            v -> opinionItem.setLastScanDate(TimeHelper.parseISO860Date(v.toString())));
+            v -> opinionItem.setLastScanDate(TimeHelper.parseISO8601Date(v.toString())));
         withStringValue(data, List.of(MapperFields.OPINION_SERVICE_DEEP_LINK),
             v -> opinionItem.setDeepLink(v.toString()));
 

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -224,21 +225,15 @@ public class AssetDocumentHelper {
         }
 
 
-        if (dto.getOpinions() == null) {
-            dto.setOpinions(new OpinionCollection());
-        }
-        var opinionItem = dto.getOpinions().getSourceAndServiceOpinion(reportingSource, reportingSourceService);
-        if (opinionItem == null) {
-            opinionItem = new OpinionItem();
-        }
+        dto.setOpinions(Optional.ofNullable(dto.getOpinions()).orElseGet(OpinionCollection::new));
+        var opinionItem = Optional.ofNullable((dto.getOpinions().getSourceAndServiceOpinion(reportingSource, reportingSourceService))).orElseGet(OpinionItem::new);
         opinionItem.setData(
             data.getOrDefault(MapperFields.RAW_DATA, "").toString());
-        OpinionItem finalOpinionItem = opinionItem;
         withValue(data, List.of(MapperFields.FIRST_SCAN_DATE), v -> {
-            finalOpinionItem.setFirstScanDate(TimeHelper.parseDiscoveryDate(v.toString()));
+            opinionItem.setFirstScanDate(TimeHelper.parseDiscoveryDate(v.toString()));
         });
         withValue(data, List.of(MapperFields.LAST_SCAN_DATE), v -> {
-            finalOpinionItem.setLastScanDate(TimeHelper.parseDiscoveryDate(v.toString()));
+            opinionItem.setLastScanDate(TimeHelper.parseDiscoveryDate(v.toString()));
         });
 
         dto.getOpinions().setOpinion(reportingSource, reportingSourceService, opinionItem);
@@ -517,11 +512,5 @@ public class AssetDocumentHelper {
 
         String FIRST_SCAN_DATE = "_first_scan_date";
         String LAST_SCAN_DATE = "_last_scan_date";
-    }
-
-
-    interface DtoSetter {
-
-        void set(Object value);
     }
 }

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -8,6 +8,7 @@ import com.paladincloud.common.util.MapHelper;
 import com.paladincloud.common.util.StringHelper;
 import com.paladincloud.common.util.TimeHelper;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -123,8 +124,10 @@ public class AssetDocumentHelper {
     }
 
     public String buildDocId(Map<String, Object> data) {
-        if (docIdFields.contains(AssetDocumentFields.LEGACY_ACCOUNT_ID) && data.get(AssetDocumentFields.LEGACY_ACCOUNT_ID) == null) {
-            data.put(AssetDocumentFields.LEGACY_ACCOUNT_ID, data.get(AssetDocumentFields.ACCOUNT_ID));
+        if (docIdFields.contains(AssetDocumentFields.LEGACY_ACCOUNT_ID)
+            && data.get(AssetDocumentFields.LEGACY_ACCOUNT_ID) == null) {
+            data.put(AssetDocumentFields.LEGACY_ACCOUNT_ID,
+                data.get(AssetDocumentFields.ACCOUNT_ID));
         }
         var docId = STR."\{dataSource}_\{type}_\{StringHelper.concatenate(data, docIdFields,
             "_")}";
@@ -239,9 +242,21 @@ public class AssetDocumentHelper {
             opinionItem.setServiceName(reportingSourceServiceDisplayName);
         }
         withValue(data, List.of(MapperFields.FIRST_SCAN_DATE),
-            v -> opinionItem.setFirstScanDate(TimeHelper.parseISO8601Date(v.toString())));
+            v -> {
+                try {
+                    opinionItem.setFirstScanDate(TimeHelper.parseISO8601Date(v.toString()));
+                } catch (DateTimeParseException e) {
+                    LOGGER.error(STR."Failed to parse first scan date: \{v}", e);
+                }
+            });
         withStringValue(data, List.of(MapperFields.LAST_SCAN_DATE),
-            v -> opinionItem.setLastScanDate(TimeHelper.parseISO8601Date(v.toString())));
+            v -> {
+                try {
+                    opinionItem.setLastScanDate(TimeHelper.parseISO8601Date(v.toString()));
+                } catch (DateTimeParseException e) {
+                    LOGGER.error(STR."Failed to parse last scan date: \{v}", e);
+                }
+            });
         withStringValue(data, List.of(MapperFields.OPINION_SERVICE_DEEP_LINK),
             v -> opinionItem.setDeepLink(v.toString()));
 

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/Assets.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/Assets.java
@@ -61,7 +61,7 @@ public class Assets {
     }
 
     public void process(String dataSource, String mapperPath, String reportingSource,
-        String reportingSourceService) {
+        String reportingSourceService, String reportingServiceDisplayName) {
         // dataSource is the underlying source of the data (gcp, aws, azure) while reporting source
         // is only set if it's different. It's different for secondary sources reporting data
         // (qualys, rapid7); in addition, reporting service is also set only if the data is from
@@ -142,6 +142,7 @@ public class Assets {
                         .accountIdToNameFn(this::accountIdToName)
                         .reportingSource(reportingSource)
                         .reportingSourceService(reportingSourceService)
+                        .reportingSourceServiceDisplayName(reportingServiceDisplayName)
                         .assetState(assetStateHelper.get(dataSource, type));
                     var mergeResponse = MergeAssets.process(assetCreator.build(), existingAssets,
                         latestAssets, existingPrimaryAssets);

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/jobs/JobExecutor.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/jobs/JobExecutor.java
@@ -122,7 +122,7 @@ public abstract class JobExecutor {
                     STR."Argument format incorrect: \{arg}; should be '--name=value");
             }
             var keyTokens = tokens[0].split("--");
-            map.put(keyTokens[keyTokens.length - 1], tokens[1]);
+            map.put(keyTokens[keyTokens.length - 1], tokens[1].trim());
         }
         return map;
     }

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/search/ElasticSearchHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/search/ElasticSearchHelper.java
@@ -160,7 +160,7 @@ public class ElasticSearchHelper {
         String query;
         if (latestOnly) {
             query = """
-                {"query":{"match":{"latest":true}}}
+                {"query": { "bool": { "must": [ { "term": { "latest": { "value": true } } }, { "term": { "_entity": { "value": "true" } } } ] } }}
                 """;
         } else {
             query = """

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/util/TimeHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/util/TimeHelper.java
@@ -2,6 +2,8 @@ package com.paladincloud.common.util;
 
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.ISODateTimeFormat;
 
 public class TimeHelper {
 
@@ -9,9 +11,6 @@ public class TimeHelper {
         "yyyy-MM-dd HH:mm:00Z");
     private static final DateTimeFormatter discoveryDateFormat = DateTimeFormatter.ofPattern(
         "yyyy-MM-dd HH:mm:ssZ");
-    private static final DateTimeFormatter iso8601DateFormat = DateTimeFormatter.ofPattern(
-        "yyyy-MM-dd'T'HH:mm:ssZ");
-
     private static final DateTimeFormatter yearMonthDayFormat = DateTimeFormatter.ofPattern(
         "yyyy-MM-dd");
 
@@ -22,23 +21,16 @@ public class TimeHelper {
         return yearMonthDayFormat.format(ZonedDateTime.now());
     }
 
-    public static String formatYearMonthDay(ZonedDateTime time) {
-        return yearMonthDayFormat.format(time);
-    }
-
     public static ZonedDateTime parseDiscoveryDate(String time) {
         return ZonedDateTime.parse(time, discoveryDateFormat);
     }
 
+    public static ZonedDateTime parseISO860Date(String time) {
+        return ISODateTimeFormat.dateTimeNoMillis().parseDateTime(time).withZone(DateTimeZone.UTC).toGregorianCalendar()
+            .toZonedDateTime();
+    }
+
     public static String formatZeroSeconds(ZonedDateTime time) {
         return zeroMinuteDateFormat.format(time);
-    }
-
-    public static String formatNowISO8601() {
-        return formatISO8601(ZonedDateTime.now());
-    }
-
-    public static String formatISO8601(ZonedDateTime time) {
-        return iso8601DateFormat.format(time);
     }
 }

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/util/TimeHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/util/TimeHelper.java
@@ -1,9 +1,8 @@
 package com.paladincloud.common.util;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
-import org.joda.time.DateTimeZone;
-import org.joda.time.format.ISODateTimeFormat;
 
 public class TimeHelper {
 
@@ -25,9 +24,9 @@ public class TimeHelper {
         return ZonedDateTime.parse(time, discoveryDateFormat);
     }
 
-    public static ZonedDateTime parseISO860Date(String time) {
-        return ISODateTimeFormat.dateTimeNoMillis().parseDateTime(time).withZone(DateTimeZone.UTC).toGregorianCalendar()
-            .toZonedDateTime();
+    public static ZonedDateTime parseISO8601Date(String time) {
+        return ZonedDateTime.parse(time, DateTimeFormatter.ISO_DATE_TIME).withZoneSameInstant(
+            ZoneOffset.UTC);
     }
 
     public static String formatZeroSeconds(ZonedDateTime time) {

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.paladincloud.common.AssetDocumentFields;
 import com.paladincloud.common.assets.AssetDTO;
+import com.paladincloud.common.assets.AssetDTO.OpinionCollection;
 import com.paladincloud.common.assets.AssetDTO.OpinionItem;
 import com.paladincloud.common.assets.AssetState;
 import com.paladincloud.common.search.ElasticQueryAssetResponse;
@@ -139,10 +140,10 @@ public class AssetDTOTests {
         var dto = new AssetDTO();
         dto.setDocId("1");
         dto.setDocType("ec2");
-        dto.setOpinions(new HashMap<>());
+        dto.setOpinions(new OpinionCollection());
         var opinionItem = new OpinionItem();
         opinionItem.setData("licorice");
-        dto.getOpinions().put("secondary", Map.of("flavor", opinionItem));
+        dto.getOpinions().setOpinion("secondary", "flavor", opinionItem);
         return dto;
     }
 

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDTOTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.paladincloud.common.AssetDocumentFields;
 import com.paladincloud.common.assets.AssetDTO;
+import com.paladincloud.common.assets.AssetDTO.OpinionItem;
 import com.paladincloud.common.assets.AssetState;
 import com.paladincloud.common.search.ElasticQueryAssetResponse;
 import com.paladincloud.common.util.JsonHelper;
@@ -139,7 +140,9 @@ public class AssetDTOTests {
         dto.setDocId("1");
         dto.setDocType("ec2");
         dto.setOpinions(new HashMap<>());
-        dto.getOpinions().put("secondary", Map.of("flavor", "licorice"));
+        var opinionItem = new OpinionItem();
+        opinionItem.setData("licorice");
+        dto.getOpinions().put("secondary", Map.of("flavor", opinionItem));
         return dto;
     }
 

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
@@ -51,10 +51,13 @@ public class AssetDocumentHelperOpinionTests {
         assertNull(dto.getRegion());
 
         // Validate the opinion is stored properly
-        var opinions = dto.getOpinions();
-        Map<String, String> opinionDetails = opinions.get("secondary");
-        assertNotNull(opinionDetails);
-        assertEquals(mapperData.get("rawData"), opinionDetails.get("assets"));
+        var secondaryOpinion = dto.getOpinions().get("secondary");
+        assertNotNull(secondaryOpinion);
+        var opinionItem = secondaryOpinion.get("assets");
+        assertNotNull(opinionItem);
+        assertEquals(mapperData.get("rawData"), opinionItem.getData());
+        assertNotNull(opinionItem.getFirstScanDate());
+        assertNotNull(opinionItem.getLastScanDate());
 
         // Ensure each value in the sample asset exists in the serialized/deserialized instance
         expectedMap.forEach((key, value) -> {
@@ -76,10 +79,11 @@ public class AssetDocumentHelperOpinionTests {
         mapperData.put("rawData", newRawData);
         helper.updateFrom(mapperData, dto);
 
-        var opinions = dto.getOpinions();
-        Map<String, String> opinionDetails = opinions.get("secondary");
-        assertNotNull(opinionDetails);
-        assertEquals(newRawData, opinionDetails.get("assets"));
+        var secondaryOpinion = dto.getOpinions().get("secondary");
+        assertNotNull(secondaryOpinion);
+        var opinionItem = secondaryOpinion.get("assets");
+        assertNotNull(opinionItem);
+        assertEquals(newRawData, opinionItem.getData());
     }
 
     private String getOpinionMapperDocument() {
@@ -93,12 +97,12 @@ public class AssetDocumentHelperOpinionTests {
                 "account_name": "main",
                 "projectId": "central-run-3433",
                 "source": "gcp",
-                "reporting_source": "secondary",
-                "reporting_service": "assets",
                 "source_display_name": "GCP",
                 "region": "us-central1-a",
                 "_entityType": "vminstance",
-                "_entityTypeDisplayName": "VM"
+                "_entityTypeDisplayName": "VM",
+                "_first_scan_date": "2024-09-05 14:57:00+0000",
+                "_last_scan_date": "2024-10-31 18:33:19+0000"
             }""".trim();
     }
 
@@ -115,7 +119,11 @@ public class AssetDocumentHelperOpinionTests {
                     "_docType": "vminstance",
                     "opinions": {
                         "secondary": {
-                            "assets": "{\\"flavor\\":\\"licorice\\"}"
+                            "assets": {
+                                "data": "{\\"flavor\\":\\"licorice\\"}",
+                                "firstScanDate": "2024-09-05 14:57:00+0000",
+                                "lastScanDate": "2024-10-31 18:33:00+0000"
+                            }
                         }
                     }
                 }

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
@@ -119,8 +119,8 @@ public class AssetDocumentHelperOpinionTests {
                         "secondary": {
                             "assets": {
                                 "data": "{\\"flavor\\":\\"licorice\\"}",
-                                "firstScanDate": "2024-09-05 14:57:00+0000",
-                                "lastScanDate": "2024-10-31 18:33:00+0000",
+                                "firstScanDate": "2024-09-05T14:57:00+0000",
+                                "lastScanDate": "2024-10-31T18:33:00+0000",
                                 "serviceName": "Assets API",
                                 "deepLink": "https://fubar.com"
                             }

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
@@ -30,6 +30,7 @@ public class AssetDocumentHelperOpinionTests {
             .resourceNameField("resource_name")
             .reportingSource("secondary")
             .reportingSourceService("assets")
+            .reportingSourceServiceDisplayName("Assets API")
             .build();
     }
 
@@ -97,8 +98,9 @@ public class AssetDocumentHelperOpinionTests {
                 "region": "us-central1-a",
                 "_entityType": "vminstance",
                 "_entityTypeDisplayName": "VM",
-                "_first_scan_date": "2024-09-05 14:57:00+0000",
-                "_last_scan_date": "2024-10-31 18:33:19+0000"
+                "_first_scan_date": "2024-09-05T14:57:00Z",
+                "_last_scan_date": "2024-10-31T18:33:19Z",
+                "_deep_link": "https://fubar.com"
             }""".trim();
     }
 
@@ -118,7 +120,9 @@ public class AssetDocumentHelperOpinionTests {
                             "assets": {
                                 "data": "{\\"flavor\\":\\"licorice\\"}",
                                 "firstScanDate": "2024-09-05 14:57:00+0000",
-                                "lastScanDate": "2024-10-31 18:33:00+0000"
+                                "lastScanDate": "2024-10-31 18:33:00+0000",
+                                "serviceName": "Assets API",
+                                "deepLink": "https://fubar.com"
                             }
                         }
                     }

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperOpinionTests.java
@@ -51,9 +51,7 @@ public class AssetDocumentHelperOpinionTests {
         assertNull(dto.getRegion());
 
         // Validate the opinion is stored properly
-        var secondaryOpinion = dto.getOpinions().get("secondary");
-        assertNotNull(secondaryOpinion);
-        var opinionItem = secondaryOpinion.get("assets");
+        var opinionItem = dto.getOpinions().getSourceAndServiceOpinion("secondary", "assets");
         assertNotNull(opinionItem);
         assertEquals(mapperData.get("rawData"), opinionItem.getData());
         assertNotNull(opinionItem.getFirstScanDate());
@@ -79,9 +77,7 @@ public class AssetDocumentHelperOpinionTests {
         mapperData.put("rawData", newRawData);
         helper.updateFrom(mapperData, dto);
 
-        var secondaryOpinion = dto.getOpinions().get("secondary");
-        assertNotNull(secondaryOpinion);
-        var opinionItem = secondaryOpinion.get("assets");
+        var opinionItem = dto.getOpinions().getSourceAndServiceOpinion("secondary", "assets");
         assertNotNull(opinionItem);
         assertEquals(newRawData, opinionItem.getData());
     }

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/AssetDocumentHelperTests.java
@@ -23,7 +23,7 @@ public class AssetDocumentHelperTests {
         return AssetDocumentHelper.builder()
             .loadDate(ZonedDateTime.now())
             .idField(idField)
-            .docIdFields(List.of("accountid", "region", idField))
+            .docIdFields(List.of("region", idField))
             .dataSource(dataSource)
             .displayName("ec2")
             .tags(List.of())

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/MergeOpinionsTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/MergeOpinionsTests.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.paladincloud.common.AssetDocumentFields;
 import com.paladincloud.common.assets.AssetDTO;
+import com.paladincloud.common.assets.AssetDTO.OpinionItem;
 import com.paladincloud.common.assets.AssetDocumentHelper;
 import com.paladincloud.common.assets.AssetState;
 import com.paladincloud.common.assets.MergeAssets;
@@ -41,8 +42,10 @@ public class MergeOpinionsTests {
             var asset = new AssetDTO();
             asset.setDocId(id);
             asset.setSource(reportingSource);
+            var opinionItem = new OpinionItem();
+            opinionItem.setData(rawData != null ? rawData : defaultRawData);
             asset.setOpinions(Map.of(dataSource,
-                Map.of(defaultReportingService, rawData != null ? rawData : defaultRawData)));
+                Map.of(defaultReportingService, opinionItem)));
 
             existing.put(asset.getDocId(), asset);
         });
@@ -58,7 +61,13 @@ public class MergeOpinionsTests {
         } else {
             sourceOpinion = new HashMap<>(sourceOpinion);
         }
-        sourceOpinion.put(service, rawData);
+        var serviceOpinion = sourceOpinion.get(service);
+        if (serviceOpinion == null) {
+            serviceOpinion = new OpinionItem();
+        }
+
+        serviceOpinion.setData(rawData);
+        sourceOpinion.put(service, serviceOpinion);
         opinions.put(source, sourceOpinion);
         asset.setOpinions(opinions);
     }
@@ -143,7 +152,7 @@ public class MergeOpinionsTests {
         assertNotNull(asset);
         var secondaryOpinion = asset.getOpinions().get(defaultReportingSource);
         assertNotNull(secondaryOpinion);
-        assertEquals(secondRawData, secondaryOpinion.get(defaultReportingService));
+        assertEquals(secondRawData, secondaryOpinion.get(defaultReportingService).getData());
     }
 
     // Given an existing stub and opinion, an additional opinion from the same source is added
@@ -162,8 +171,8 @@ public class MergeOpinionsTests {
         assertNotNull(asset);
         var secondaryOpinion = asset.getOpinions().get(defaultReportingSource);
         assertNotNull(secondaryOpinion);
-        assertEquals(defaultRawData, secondaryOpinion.get(defaultReportingService));
-        assertEquals(secondRawData, secondaryOpinion.get(secondReportingService));
+        assertEquals(defaultRawData, secondaryOpinion.get(defaultReportingService).getData());
+        assertEquals(secondRawData, secondaryOpinion.get(secondReportingService).getData());
     }
 
     // Given an existing stub and opinion, an additional opinion from a different source is added
@@ -184,8 +193,8 @@ public class MergeOpinionsTests {
         assertNotNull(defaultOpinion);
         var otherOpinion = asset.getOpinions().get(secondReportingSource);
         assertNotNull(otherOpinion);
-        assertEquals(defaultRawData, defaultOpinion.get(defaultReportingService));
-        assertEquals(secondRawData, otherOpinion.get(secondReportingService));
+        assertEquals(defaultRawData, defaultOpinion.get(defaultReportingService).getData());
+        assertEquals(secondRawData, otherOpinion.get(secondReportingService).getData());
     }
 
     // Given both a stub & opinion asset, the opinion is missing from the latest.

--- a/assets-management/services/svc-asset-delta-engine/test-data/qualys-azure-virtualmachine.json
+++ b/assets-management/services/svc-asset-delta-engine/test-data/qualys-azure-virtualmachine.json
@@ -3,7 +3,7 @@
     {
       "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
       "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
-      "body": "--tenant_id=98c28482-9bae-46bd-bd4e-58fa132e72c0 --data_source=gcp --s3_path=mapper-results/98c28482-9bae-46bd-bd4e-58fa132e72c0/qualys/20241022-153147/gcp --reporting_source=qualys --reporting_source_service=vulnerabilities_management \"--reporting_source_service_display_name=Vulnerability Management\" --asset_type_override=vminstance --omit_done_event=true --skip_asset_count=true",
+      "body": "--tenant_id=98c28482-9bae-46bd-bd4e-58fa132e72c0 --data_source=azure --s3_path=mapper-results/98c28482-9bae-46bd-bd4e-58fa132e72c0/qualys/20241022-153147/azure --reporting_source=qualys --reporting_source_service=vulnerabilities_management \"--reporting_source_service_display_name=Vulnerability Management\" --asset_type_override=virtualmachine --omit_done_event=true --skip_asset_count=true",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1545082649183",

--- a/assets-management/services/svc-asset-delta-engine/test-data/qualyz-aws-ec2.json
+++ b/assets-management/services/svc-asset-delta-engine/test-data/qualyz-aws-ec2.json
@@ -3,7 +3,7 @@
     {
       "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
       "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
-      "body": "--tenant_id=98c28482-9bae-46bd-bd4e-58fa132e72c0 --data_source=gcp --s3_path=mapper-results/98c28482-9bae-46bd-bd4e-58fa132e72c0/qualys/20241022-153147/gcp --reporting_source=qualys --reporting_source_service=vulnerabilities_management \"--reporting_source_service_display_name=Vulnerability Management\" --asset_type_override=vminstance --omit_done_event=true --skip_asset_count=true",
+      "body": "--tenant_id=98c28482-9bae-46bd-bd4e-58fa132e72c0 --data_source=aws --s3_path=mapper-results/98c28482-9bae-46bd-bd4e-58fa132e72c0/qualys/20241022-153147/aws --reporting_source=qualys --reporting_source_service=vulnerabilities_management \"--reporting_source_service_display_name=Vulnerability Management\" --asset_type_override=ec2 --omit_done_event=true --skip_asset_count=true",
       "attributes": {
         "ApproximateReceiveCount": "1",
         "SentTimestamp": "1545082649183",


### PR DESCRIPTION
A single opinion has been expanded from being a string to an object that includes the string (data) and optional scan dates.
If the mapper provides the first and last scan date, those will be populated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new `OpinionCollection` class for enhanced management of opinions within asset data.
	- Updated asset opinions structure to allow for detailed metadata (first and last scan dates).
	- Enhanced asset document handling to support the new opinion structure.
	- Added new constants and parameters to improve asset processing and logging.
	- Introduced new JSON files for testing asset message processing.

- **Bug Fixes**
	- Improved error handling and validation for opinion data within asset documents.

- **Tests**
	- Updated test cases to reflect the new structure of opinions, ensuring robust validation of opinion data.
	- Modified existing test data to align with recent changes in asset processing logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->