### PR TITLE
fix:[NEXT-335] Update correct fields to get from OS doc

### DIFF
--- a/ui-asset-management/api/svc-asset-details/extension/constants/asset_model_fields.go
+++ b/ui-asset-management/api/svc-asset-details/extension/constants/asset_model_fields.go
@@ -17,12 +17,12 @@
 package constants
 
 const (
-	AccountId       = "accountId"
-	AccountName     = "accountName"
+	AccountId       = "account_id"
+	AccountName     = "account_name"
 	Source          = "source"
-	SourceName      = "sourceName"
-	TargetType      = "targetType"
-	TargetTypeName  = "targetTypeName"
+	SourceName      = "sourceDisplayName"
+	TargetType      = "_entityType"
+	TargetTypeName  = "_entityTypeDisplayName"
 	Region          = "region"
 	PrimaryProvider = "primaryProvider"
 	RawData         = "rawData"


### PR DESCRIPTION
- update correct field names to pick from the v2 asset model doc, which was changed during refactoring 
![image](https://github.com/user-attachments/assets/9ad02959-e7f0-4321-bafa-1c4e7406d315)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated naming conventions for asset-related constants to improve clarity and consistency.
		- `AccountId` and `AccountName` now use snake_case.
		- `SourceName` renamed to `SourceDisplayName`.
		- `TargetType` and `TargetTypeName` renamed to `_entityType` and `_entityTypeDisplayName`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->