### PR TITLE
fix:[NEXT-367] Add resourceId to the asset details V2 response

### DIFF
--- a/ui-asset-management/api/svc-asset-details/extension/clients/asset_details_client.go
+++ b/ui-asset-management/api/svc-asset-details/extension/clients/asset_details_client.go
@@ -105,6 +105,7 @@ func (c *AssetDetailsClient) GetAssetDetails(ctx context.Context, tenantId, asse
 			Tags:            tags,
 			MandatoryTags:   mandatoryTags,
 			PrimaryProvider: primaryProvider,
+			ResourceId:      commonFields[constants.ResourceId],
 		},
 		Message: message,
 	}
@@ -225,6 +226,8 @@ func (c *AssetDetailsClient) buildLegacyCommonFields(assetDetails map[string]int
 				commonFields[constants.Region] = fmt.Sprintf("%v", value)
 			case legacy_constants.AssetState:
 				commonFields[constants.AssetState] = fmt.Sprintf("%v", value)
+			case legacy_constants.ResourceId:
+				commonFields[constants.ResourceId] = fmt.Sprintf("%v", value)
 			}
 		}
 	}

--- a/ui-asset-management/api/svc-asset-details/extension/constants/asset_model_fields.go
+++ b/ui-asset-management/api/svc-asset-details/extension/constants/asset_model_fields.go
@@ -26,6 +26,7 @@ const (
 	Region          = "region"
 	PrimaryProvider = "primaryProvider"
 	AssetState      = "_assetState"
+	ResourceId      = "_resourceid"
 )
 
 var CommonFields = []string{
@@ -37,6 +38,7 @@ var CommonFields = []string{
 	TargetTypeName,
 	Region,
 	AssetState,
+	ResourceId,
 }
 
 const (

--- a/ui-asset-management/api/svc-asset-details/extension/legacy_constants/legacy_asset_model_fields.go
+++ b/ui-asset-management/api/svc-asset-details/extension/legacy_constants/legacy_asset_model_fields.go
@@ -58,6 +58,7 @@ const (
 	TargetTypeName = "targettypedisplayname"
 	Region         = "region"
 	AssetState     = "_assetState"
+	ResourceId     = "_resourceid"
 )
 
 var CommonFields = []string{
@@ -69,6 +70,7 @@ var CommonFields = []string{
 	TargetTypeName,
 	Region,
 	AssetState,
+	ResourceId,
 }
 
 func IsCommonField(field string) bool {

--- a/ui-asset-management/api/svc-asset-details/extension/models/asset_details.go
+++ b/ui-asset-management/api/svc-asset-details/extension/models/asset_details.go
@@ -7,6 +7,7 @@ type AssetDetails struct {
 	SourceName      string            `json:"SourceName"`
 	TargetType      string            `json:"targetType"`
 	TargetTypeName  string            `json:"targetTypeName"`
+	ResourceId      string            `json:"resourceId"`
 	Region          string            `json:"region"`
 	AssetState      string            `json:"assetState"`
 	Tags            map[string]string `json:"tags"`


### PR DESCRIPTION
- Added resourceId to the asset details V2 response
![image](https://github.com/user-attachments/assets/8f82cb07-4301-4b34-bd1b-97fef8684465)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asset detail retrieval with the addition of a `ResourceId` field in the response.
	- Improved error handling for asset states, particularly for "suspicious" assets.

- **Bug Fixes**
	- Refined error handling in the extraction of primary provider data.

- **Documentation**
	- Updated constants to include `ResourceId`, ensuring consistency across the application.

- **Refactor**
	- Improved overall structure of the asset details response with the integration of new fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->