### PR TITLE
fix:[NEXT-402] Fetch docs correctly by docId

### DIFF
--- a/ui-asset-management/api/svc-asset-network-rules/extension/clients/elasticsearch_client.go
+++ b/ui-asset-management/api/svc-asset-network-rules/extension/clients/elasticsearch_client.go
@@ -114,15 +114,21 @@ func (c *ElasticSearchClient) FetchChildResourcesDetails(ctx context.Context, te
 }
 
 func buildDetailsQuery(assetId string) map[string]interface{} {
-	assetIdFilter := map[string]interface{}{
+	assetIdFilter := buildDocIdFilter(assetId)
+	entityFilter := map[string]interface{}{
 		"term": map[string]interface{}{
-			"_id": assetId,
+			"_entity": "true",
+		},
+	}
+	latestFilter := map[string]interface{}{
+		"term": map[string]interface{}{
+			"latest": "true",
 		},
 	}
 
 	query := map[string]interface{}{
 		"bool": map[string]interface{}{
-			"must": [1]map[string]interface{}{assetIdFilter},
+			"must": [3]map[string]interface{}{assetIdFilter, entityFilter, latestFilter},
 		},
 	}
 
@@ -154,4 +160,25 @@ func buildChildResourcesQuery(targetType string, assetId string) map[string]inte
 	}
 
 	return query
+}
+
+func buildDocIdFilter(docId string) map[string]interface{} {
+
+	docIdFilter1 := map[string]interface{}{
+		"term": map[string]interface{}{
+			"_docid.keyword": docId,
+		},
+	}
+	docIdFilter2 := map[string]interface{}{
+		"term": map[string]interface{}{
+			"_docId.keyword": docId,
+		},
+	}
+
+	docIdOrFilter := map[string]interface{}{
+		"bool": map[string]interface{}{
+			"should": []interface{}{docIdFilter1, docIdFilter2},
+		},
+	}
+	return docIdOrFilter
 }

--- a/ui-asset-management/api/svc-asset-opinions/extension/clients/asset_opinions_client.go
+++ b/ui-asset-management/api/svc-asset-opinions/extension/clients/asset_opinions_client.go
@@ -46,7 +46,7 @@ func (c *AssetOpinionsClient) GetAssetOpinions(ctx context.Context, tenantId, so
 
 	log.Printf("starting to fetch opinions for asset id [%s] and tenant id [%s]\n", assetId, tenantId)
 
-	result, err := c.elasticSearchClient.FetchAssetOpinions(ctx, tenantId, source, targetType, assetId)
+	result, err := c.elasticSearchClient.FetchAssetOpinions(ctx, tenantId, strings.ToLower(source), strings.ToLower(targetType), assetId)
 	if err != nil {
 		log.Printf("error fetching asset Opinions: %+v", err)
 		return &models.Response{Data: nil, Message: "No opinions available for this asset"}, nil

--- a/ui-asset-management/api/svc-asset-opinions/extension/clients/elasticsearch_client.go
+++ b/ui-asset-management/api/svc-asset-opinions/extension/clients/elasticsearch_client.go
@@ -83,11 +83,7 @@ func (c *ElasticSearchClient) FetchAssetOpinions(ctx context.Context, tenantId, 
 }
 
 func buildOpinionsQuery(assetId string) map[string]interface{} {
-	assetIdFilter := map[string]interface{}{
-		"term": map[string]interface{}{
-			"_id": assetId,
-		},
-	}
+	assetIdFilter := buildDocIdFilter(assetId)
 
 	query := map[string]interface{}{
 		"bool": map[string]interface{}{
@@ -96,4 +92,25 @@ func buildOpinionsQuery(assetId string) map[string]interface{} {
 	}
 
 	return query
+}
+
+func buildDocIdFilter(docId string) map[string]interface{} {
+
+	docIdFilter1 := map[string]interface{}{
+		"term": map[string]interface{}{
+			"_docid.keyword": docId,
+		},
+	}
+	docIdFilter2 := map[string]interface{}{
+		"term": map[string]interface{}{
+			"_docId.keyword": docId,
+		},
+	}
+
+	docIdOrFilter := map[string]interface{}{
+		"bool": map[string]interface{}{
+			"should": []interface{}{docIdFilter1, docIdFilter2},
+		},
+	}
+	return docIdOrFilter
 }

--- a/ui-asset-management/api/svc-asset-related-assets/extension/clients/elasticsearch_client.go
+++ b/ui-asset-management/api/svc-asset-related-assets/extension/clients/elasticsearch_client.go
@@ -149,15 +149,21 @@ func (c *ElasticSearchClient) fetchFromOpensearch(ctx context.Context, tenantId,
 }
 
 func buildDetailsQuery(assetId string) map[string]interface{} {
-	assetIdFilter := map[string]interface{}{
+	assetIdFilter := buildDocIdFilter(assetId)
+	entityFilter := map[string]interface{}{
 		"term": map[string]interface{}{
-			"_id": assetId,
+			"_entity": "true",
+		},
+	}
+	latestFilter := map[string]interface{}{
+		"term": map[string]interface{}{
+			"latest": "true",
 		},
 	}
 
 	query := map[string]interface{}{
 		"bool": map[string]interface{}{
-			"must": [1]map[string]interface{}{assetIdFilter},
+			"must": [3]map[string]interface{}{assetIdFilter, entityFilter, latestFilter},
 		},
 	}
 
@@ -206,4 +212,25 @@ func buildAssetsQuery(docType, resourceId string) map[string]interface{} {
 	}
 
 	return query
+}
+
+func buildDocIdFilter(docId string) map[string]interface{} {
+
+	docIdFilter1 := map[string]interface{}{
+		"term": map[string]interface{}{
+			"_docid.keyword": docId,
+		},
+	}
+	docIdFilter2 := map[string]interface{}{
+		"term": map[string]interface{}{
+			"_docId.keyword": docId,
+		},
+	}
+
+	docIdOrFilter := map[string]interface{}{
+		"bool": map[string]interface{}{
+			"should": []interface{}{docIdFilter1, docIdFilter2},
+		},
+	}
+	return docIdOrFilter
 }


### PR DESCRIPTION
- fetch asset doc by either _docid or docId to handle legacy and asset model V2
- previously fetched the doc by _id, but now changed it to docid to match with what asset list page is fetching the assetId from (asset list page fetched the assetId from docid field)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new document ID filtering function to enhance query capabilities across various asset management components.
	- Enhanced query construction to include additional filters for improved asset detail retrieval.

- **Bug Fixes**
	- Ensured consistent formatting of input parameters in the asset opinions fetching process.

- **Refactor**
	- Modularized query construction by delegating document ID filter creation to a dedicated function, improving code clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->