### PR TITLE
[NEXT-318] Honor asset service feature flag

### DIFF
--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/ApplicationModule.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/ApplicationModule.java
@@ -5,6 +5,7 @@ import com.paladincloud.common.assets.AssetCountsHelper;
 import com.paladincloud.common.assets.AssetGroupStatsCollector;
 import com.paladincloud.common.assets.AssetGroups;
 import com.paladincloud.common.assets.AssetRepository;
+import com.paladincloud.common.assets.AssetStateHelper;
 import com.paladincloud.common.assets.Assets;
 import com.paladincloud.common.assets.DataSourceHelper;
 import com.paladincloud.common.assets.ElasticAssetRepository;
@@ -56,8 +57,8 @@ public class ApplicationModule {
 
     @Singleton
     @Provides
-    Assets provideAssets(AssetRepository assetRepository, AssetTypes assetTypes, MapperRepository mapperRepository, DatabaseHelper databaseHelper) {
-        return new Assets(assetRepository, assetTypes, mapperRepository, databaseHelper);
+    Assets provideAssets(AssetRepository assetRepository, AssetTypes assetTypes, MapperRepository mapperRepository, DatabaseHelper databaseHelper, AssetStateHelper assetStateHelper) {
+        return new Assets(assetRepository, assetTypes, mapperRepository, databaseHelper, assetStateHelper);
     }
 
     @Singleton

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -116,6 +116,8 @@ public class AssetDocumentHelper {
     private String reportingSource;
     private String reportingSourceService;
     private String reportingSourceServiceDisplayName;
+    private AssetState assetState;
+    private boolean assetStateServiceEnabled;
 
 
     public boolean isPrimarySource() {
@@ -166,6 +168,9 @@ public class AssetDocumentHelper {
         // Set the remaining asset fields
         if (isPrimarySource()) {
             dto.setSource(source.toLowerCase());
+            if (!assetStateServiceEnabled) {
+                dto.setAssetState(assetState);
+            }
             populateNewPrimary(data, dto, idValue);
         } else {
             populateNewOpinion(data, dto);
@@ -178,7 +183,11 @@ public class AssetDocumentHelper {
         dto.setLegacySource(dto.getSource());
         dto.setLegacyDocId(dto.getDocId());
         dto.setLegacyDocType(dto.getDocType());
-        dto.setAssetState(AssetState.RECONCILING);
+        if (assetStateServiceEnabled) {
+            dto.setAssetState(AssetState.RECONCILING);
+        } else {
+            dto.setAssetState(assetState);
+        }
 
         setCommonPrimaryFields(data, dto, idValue);
 
@@ -291,7 +300,11 @@ public class AssetDocumentHelper {
         dto.setLegacyDocId(dto.getDocId());
         dto.setLegacyDocType(dto.getDocType());
 
-        dto.setAssetState(AssetState.RECONCILING);
+        if (assetStateServiceEnabled) {
+            dto.setAssetState(AssetState.RECONCILING);
+        } else {
+            dto.setAssetState(AssetState.SUSPICIOUS);
+        }
         return dto;
     }
 

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetStateHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetStateHelper.java
@@ -1,0 +1,43 @@
+package com.paladincloud.common.assets;
+
+import com.paladincloud.common.aws.DatabaseHelper;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+@Singleton
+public class AssetStateHelper {
+
+    private final DatabaseHelper databaseHelper;
+
+    private final Map<String, Map<String, Integer>> sourceTypeMap = new HashMap<>();
+
+    @Inject
+    public AssetStateHelper(DatabaseHelper databaseHelper) {
+        this.databaseHelper = databaseHelper;
+    }
+
+    public AssetState get(String dataSource, String assetType) {
+        var typeCountMap = getSourceTypeMap(dataSource);
+        if (typeCountMap.getOrDefault(assetType, 0).equals(0)) {
+            return AssetState.UNMANAGED;
+        }
+        return AssetState.MANAGED;
+    }
+
+    private Map<String, Integer> getSourceTypeMap(String dataSource) {
+        if (!sourceTypeMap.containsKey(dataSource)) {
+            var typeCountMap = new HashMap<String, Integer>();
+            databaseHelper.executeQuery(
+                    STR."SELECT targetType,count(*) FROM pacmandata.cf_PolicyTable WHERE assetGroup = '\{dataSource}' AND status = 'ENABLED' GROUP BY targetType")
+                .forEach(row -> {
+                    var type = row.get("targetType");
+                    var count = row.get("count(*)");
+                    typeCountMap.put(type, Integer.parseInt(count));
+                });
+            sourceTypeMap.put(dataSource, typeCountMap);
+        }
+        return sourceTypeMap.get(dataSource);
+    }
+}

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/config/ConfigService.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/config/ConfigService.java
@@ -32,6 +32,9 @@ public class ConfigService {
         return properties.getProperty(propertyName, defaultValue);
     }
 
+    public static boolean isFeatureEnabled(String feature) {
+        return "true".equalsIgnoreCase(properties.getProperty("feature_flags." + feature, "false"));
+    }
 
     /**
      * Retrieve configuration properties from the given config service, making them available in the
@@ -66,7 +69,8 @@ public class ConfigService {
     private static Map<String, String> getSecretsWithRole(ConfigParams configParams) {
         return RoleHelper.runAs(configParams.awsRegion, null, configParams.assumeRoleArn,
             secretCredentialsProvider -> {
-                var builder = SecretsManagerClient.builder().region(Region.of(configParams.awsRegion));
+                var builder = SecretsManagerClient.builder()
+                    .region(Region.of(configParams.awsRegion));
                 if (secretCredentialsProvider != null) {
                     builder.credentialsProvider(secretCredentialsProvider);
                 }
@@ -104,7 +108,8 @@ public class ConfigService {
                 var table = configParams.tenantConfigTable;
                 var tableKey = configParams.tenantConfigTablePartitionKey;
                 return DynamoDBHelper.get(configParams.awsRegion, dynamoCredentialsProviders,
-                    table, tableKey, configParams.tenantId, Map.of("api_feature_flags", "feature_flags"));
+                    table, tableKey, configParams.tenantId,
+                    Map.of("api_feature_flags", "feature_flags"));
             });
     }
 

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/MergeAssetsTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/MergeAssetsTests.java
@@ -59,6 +59,7 @@ public class MergeAssetsTests {
             .displayName(type)
             .tags(List.of())
             .type(type)
+            .assetStateServiceEnabled(true)
             .accountIdToNameFn((_) -> null)
             .resourceNameField("resource_name")
             .reportingSource(opinionSource)

--- a/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/MergeOpinionsTests.java
+++ b/assets-management/services/svc-asset-delta-engine/src/test/java/com/paladincloud/commons/assets/MergeOpinionsTests.java
@@ -99,6 +99,7 @@ public class MergeOpinionsTests {
             .tags(List.of())
             .type("vminstance")
             .accountIdToNameFn((_) -> null)
+            .assetStateServiceEnabled(true)
             .resourceNameField("resource_name")
             .reportingSource(reportingSource)
             .reportingSourceService(reportingService)


### PR DESCRIPTION
When the flag is enabled (the asset state service will be used)
1. For existing assets, the state is NOT set
2. For new assets, the state is set to RECONCILING
3. For the SQS event sent when complete, use the new output trigger environment variable


When the flag is disabled (no asset state service is used)
1. Existing assets will be set to managed/unmanaged
2. New assets will be set to managed/unmanaged
3. For the SQS event sent when complete, send the event to the policy engine



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `AssetStateHelper` for managing asset states based on data source and asset type.
	- Enhanced asset state handling in `AssetDocumentHelper` and `Assets` classes.

- **Bug Fixes**
	- Improved error handling in `JobExecutor` for missing environment variables related to asset state service.

- **Documentation**
	- Updated method signatures to reflect new parameters related to asset state management.

- **Tests**
	- Modified test helpers in `MergeAssetsTests` and `MergeOpinionsTests` to incorporate asset state service functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->