### PR TITLE
Correctly set the resourceName field, support k8s containers

### DIFF
--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/assetsender/AssetSenderJob.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/assetsender/AssetSenderJob.java
@@ -65,6 +65,17 @@ public class AssetSenderJob extends JobExecutor {
             Collections.singletonMap("s3.data", params.get(S3_PATH)));
 
         var reportingSource = params.get(REPORTING_SOURCE);
+        var reportingSourceService = params.get(REPORTING_SOURCE_SERVICE);
+        var reportingSourceServiceDisplayName = params.get(REPORTING_SOURCE_SERVICE_DISPLAY_NAME);
+
+        // Until this information comes from elsewhere this code has a hack to treat a reporting
+        // source of k8s as the original source -- essentially ignoring reporting source.
+        if ("k8s".equalsIgnoreCase(reportingSource)) {
+            reportingSource = null;
+            reportingSourceService = null;
+            reportingSourceServiceDisplayName = null;
+            LOGGER.info("Ignoring K8S reporting source, using {} as the source", dataSource);
+        }
 
         // dataSource is the underlying source of the data (gcp, aws, azure) while reporting source
         // is only set if it's different. It's different for secondary sources reporting data
@@ -77,8 +88,8 @@ public class AssetSenderJob extends JobExecutor {
         }
         var processedAssetTypes = assets.process(dataSource, params.get(S3_PATH), isOpinion,
             reportingSource,
-            params.get(REPORTING_SOURCE_SERVICE),
-            params.get(REPORTING_SOURCE_SERVICE_DISPLAY_NAME));
+            reportingSourceService,
+            reportingSourceServiceDisplayName);
 
         if (!isOpinion) {
             if ("true".equalsIgnoreCase(ConfigService.get(Dev.SKIP_ASSET_COUNT))) {

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -53,6 +53,7 @@ public class AssetDocumentHelper {
             MapperFields.REPORTING_SERVICE,
             MapperFields.FIRST_SCAN_DATE,
             MapperFields.LAST_SCAN_DATE,
+            MapperFields.ENTITY_TYPE_DISPLAY_NAME,
 
             AssetDocumentFields.LEGACY_NAME,
             AssetDocumentFields.ASSET_ID_DISPLAY_NAME,
@@ -565,6 +566,8 @@ public class AssetDocumentHelper {
         String RAW_DATA = "rawData";
         String REPORTING_SOURCE = "reporting_source";
         String REPORTING_SERVICE = "reporting_service";
+
+        String ENTITY_TYPE_DISPLAY_NAME = "_entityTypeDisplayName";
 
         String SOURCE_DISPLAY_NAME = "source_display_name";
         String LEGACY_SOURCE_DISPLAY_NAME = "sourceDisplayName";

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/Assets.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/Assets.java
@@ -140,6 +140,7 @@ public class Assets {
                         .accountIdToNameFn(this::accountIdToName)
                         .assetState(assetStateHelper.get(dataSource, type))
                         .assetStateServiceEnabled(ConfigService.isFeatureEnabled("enableAssetStateService"))
+                        .resourceNameField(assetTypes.getResourceNameType(dataSource, type))
                         .reportingSource(reportingSource)
                         .reportingSourceService(reportingSourceService)
                         .reportingSourceServiceDisplayName(reportingServiceDisplayName);


### PR DESCRIPTION
1. Utilize the 'name' field from the cf_Target table; this will impact all asset types, as this configuration was being ignored prior to this.
2. Support k8s containers by using the underlying source type (gcp, for instance)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced asset processing logic to handle reporting sources more flexibly
	- Added support for capturing additional asset document fields
	- Improved resource name field retrieval during asset creation

- **Chores**
	- Updated method signatures to accommodate new asset processing requirements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->