### PR TITLE
fix:[NEXT-1933] Fix null ES ids when processing Tenable opinions

### DIFF
--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -321,7 +321,10 @@ public class AssetDocumentHelper {
         if (isPrimarySource()) {
             updatePrimary(data, dto, idValue);
         } else {
-            if (dataSource.equalsIgnoreCase(dto.getSource())) {
+            if (dataSource.equalsIgnoreCase(getSource(dto))) {
+                if (dto.getDocId() == null) {
+                    dto.setDocId(dto.getLegacyDocId());
+                }
                 updatePrimaryFromSecondary(data, dto, idValue);
             } else {
                 updateOpinion(data, dto);
@@ -538,6 +541,13 @@ public class AssetDocumentHelper {
             throw new JobException("Mapper data is missing the 'source' field");
         }
         return source;
+    }
+
+    private String getSource(AssetDTO dto) {
+        if (dto.getSource() != null) {
+            return dto.getSource();
+        }
+        return dto.getLegacySource();
     }
 
     private void withValue(Map<String, Object> data, List<String> key,


### PR DESCRIPTION
This happened against legacy documents, AWS in this case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced asset document identification with more robust source resolution.
  * Improved handling of legacy assets through better source matching and data fallback mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->