### PR TITLE
fix:[NEXT-1948] Properly encode URL parameters, filter out null values

### DIFF
--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetCountsHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetCountsHelper.java
@@ -32,8 +32,12 @@ public class AssetCountsHelper {
         this.databaseHelper = databaseHelper;
     }
 
+    public String encodeUrlParameter(String parameter) {
+        return URLEncoder.encode(parameter, StandardCharsets.UTF_8);
+    }
+
     public List<Map<String, Object>> fetchTypeCounts(String assetGroup) throws Exception {
-        var url = buildPaladinApiUrl(ASSET_SERVICE_BASE_PATH, STR."/count?ag=\{assetGroup}");
+        var url = buildPaladinApiUrl(ASSET_SERVICE_BASE_PATH, STR."/count?ag=\{encodeUrlParameter(assetGroup)}");
         var headers = HttpHelper.getBasicHeaders(AuthorizationType.BEARER, authHelper.getToken());
         headers.put("cache-control", "no-cache");
         var typeCountMap = JsonHelper.mapFromString(HttpHelper.get(url, headers));
@@ -78,8 +82,7 @@ public class AssetCountsHelper {
         List<Map<String, Object>> compInfo = new ArrayList<>();
         for (var domain : domains) {
             var url = buildPaladinApiUrl(COMPLIANCE_SERVICE_BASE_PATH,
-                STR."/overallcompliance?ag=\{assetGroup}&domain=\{URLEncoder.encode(domain,
-                    StandardCharsets.UTF_8)}");
+                STR."/overallcompliance?ag=\{encodeUrlParameter(assetGroup)}&domain=\{encodeUrlParameter(domain)}");
             var complianceResponse = JsonHelper.mapFromString(HttpHelper.get(url,
                 HttpHelper.getBasicHeaders(AuthorizationType.BEARER, authHelper.getToken())));
             @SuppressWarnings("unchecked") var complianceStats = ((Map<String, Map<String, Object>>) complianceResponse.get(
@@ -105,7 +108,7 @@ public class AssetCountsHelper {
     }
 
     public Map<String, Object> fetchTaggingSummary(String assetGroup) throws Exception {
-        var url = buildPaladinApiUrl(COMPLIANCE_SERVICE_BASE_PATH, STR."/tagging?ag=\{assetGroup}");
+        var url = buildPaladinApiUrl(COMPLIANCE_SERVICE_BASE_PATH, STR."/tagging?ag=\{encodeUrlParameter(assetGroup)}");
         var taggingResponse = JsonHelper.mapFromString(HttpHelper.get(url,
             HttpHelper.getBasicHeaders(AuthorizationType.BEARER, authHelper.getToken())));
         @SuppressWarnings("unchecked") var taggingStats = ((Map<String, Map<String, Object>>) taggingResponse.get(
@@ -125,8 +128,7 @@ public class AssetCountsHelper {
         var issuesList = new ArrayList<Map<String, Object>>();
         for (var domain : domains) {
             var url = buildPaladinApiUrl(COMPLIANCE_SERVICE_BASE_PATH,
-                STR."/issues/distribution?ag=\{assetGroup}&domain=\{URLEncoder.encode(domain,
-                    StandardCharsets.UTF_8)}");
+                STR."/issues/distribution?ag=\{encodeUrlParameter(assetGroup)}&domain=\{encodeUrlParameter(domain)}");
             var distributionResponse = JsonHelper.mapFromString(HttpHelper.get(url,
                 HttpHelper.getBasicHeaders(AuthorizationType.BEARER, authHelper.getToken())));
             @SuppressWarnings("unchecked") var distribution = ((Map<String, Map<String, Object>>) distributionResponse.get(
@@ -146,7 +148,7 @@ public class AssetCountsHelper {
 
     @SuppressWarnings("unchecked")
     public Map<String, Object> fetchAssetCounts(String assetGroup) throws Exception {
-        var url = buildPaladinApiUrl(ASSET_SERVICE_BASE_PATH, STR."/count?ag=\{assetGroup}");
+        var url = buildPaladinApiUrl(ASSET_SERVICE_BASE_PATH, STR."/count?ag=\{encodeUrlParameter(assetGroup)}");
         var response = JsonHelper.mapFromString(HttpHelper.get(url,
             HttpHelper.getBasicHeaders(AuthorizationType.BEARER, authHelper.getToken())));
         return (Map<String, Object>) response.get("data");
@@ -154,7 +156,7 @@ public class AssetCountsHelper {
 
     public int fetchAccountAssetCount(String platform, String accountId) throws Exception {
         var url = buildPaladinApiUrl(ASSET_SERVICE_BASE_PATH,
-            STR."/count?ag=\{platform}&accountId=\{accountId}");
+            STR."/count?ag=\{encodeUrlParameter(platform)}&accountId=\{encodeUrlParameter(accountId)}");
         var response = JsonHelper.mapFromString(HttpHelper.get(url,
             HttpHelper.getBasicHeaders(AuthorizationType.BEARER, authHelper.getToken())));
         @SuppressWarnings("unchecked") var data = (Map<String, Object>) response.get("data");

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/assets/AssetDocumentHelper.java
@@ -223,7 +223,7 @@ public class AssetDocumentHelper {
 
         // Transfer additional mapper provided fields that aren't already set
         data.forEach((key, value) -> {
-            if (!assetFields.contains(key)) {
+            if (!assetFields.contains(key) && value != null) {
                 dto.getAdditionalProperties().put(key, value);
             }
         });
@@ -350,7 +350,7 @@ public class AssetDocumentHelper {
 
         // Transfer additional mapper provided fields that aren't already set
         data.forEach((key, value) -> {
-            if (!assetFields.contains(key)) {
+            if (!assetFields.contains(key) && value != null) {
                 dto.getAdditionalProperties().put(key, value);
             }
         });

--- a/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/util/HttpHelper.java
+++ b/assets-management/services/svc-asset-delta-engine/src/main/java/com/paladincloud/common/util/HttpHelper.java
@@ -10,6 +10,7 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.HttpResponseException;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.conn.ssl.NoopHostnameVerifier;
@@ -25,7 +26,6 @@ import org.apache.logging.log4j.util.Strings;
 import software.amazon.awssdk.utils.CollectionUtils;
 
 public class HttpHelper {
-
     public enum AuthorizationType {
         BEARER("Bearer"), BASIC("Basic");
         public final String name;
@@ -35,6 +35,11 @@ public class HttpHelper {
     }
 
     private static final Logger LOGGER = LogManager.getLogger(HttpHelper.class);
+    private static final RequestConfig REQUEST_CONFIG = RequestConfig.custom()
+        .setConnectTimeout(60 * 1000)
+        .setConnectionRequestTimeout(60 * 1000)
+        .setSocketTimeout(60 * 1000)
+        .build();
 
     public static Map<String, String> getBasicHeaders(AuthorizationType authType, String authCredentials) {
         var headers = new HashMap<String, String>();
@@ -96,7 +101,9 @@ public class HttpHelper {
 
     private static CloseableHttpClient getHttpClient() {
         try {
-            return HttpClientBuilder.create().setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
+            return HttpClientBuilder.create()
+                .setDefaultRequestConfig(REQUEST_CONFIG)
+                .setSSLHostnameVerifier(NoopHostnameVerifier.INSTANCE)
                 .setSSLContext(
                     new SSLContextBuilder().loadTrustMaterial(null, (_, _) -> true).build())
                 .build();


### PR DESCRIPTION
1. Calling existing API's to get asset counts failed due to asset group names containing invalid characters for URL parameters.
2. Some (old) fields were getting set with null values, which isn't allowed with ConcurrentHashMap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced URL parameter encoding in asset queries to properly handle special characters, ensuring consistent request formatting.
  * Refined asset property population to skip null values, preventing unnecessary data entries and improving data consistency.
  * Set default network timeouts for backend requests (60s) to reduce hanging requests and improve overall request reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->